### PR TITLE
refactor and prep for disabled Cargo.toml sorting support

### DIFF
--- a/src/bazel.rs
+++ b/src/bazel.rs
@@ -4,6 +4,8 @@ use std::cmp::Ordering;
 use std::io::{self};
 use std::path::Path;
 
+const STRATEGY: SortStrategy = SortStrategy::Bazel;
+
 pub(crate) fn is_bazel(path: &Path) -> bool {
     match path.extension().and_then(|s| s.to_str()) {
         Some(ext) => matches!(ext, "bazel" | "bzl" | "BUILD" | "WORKSPACE"),
@@ -37,7 +39,7 @@ pub(crate) fn process_lines_bazel(lines: Vec<&str>) -> io::Result<Vec<&str>> {
                 && (line_without_comment.contains(']') || line.trim().is_empty())
             {
                 is_sorting_block = false;
-                sort(&mut block, SortStrategy::Bazel);
+                sort(&mut block, STRATEGY);
                 output_lines.append(&mut block);
                 output_lines.push(line);
             } else if is_sorting_block {
@@ -51,7 +53,7 @@ pub(crate) fn process_lines_bazel(lines: Vec<&str>) -> io::Result<Vec<&str>> {
     }
 
     if is_sorting_block {
-        sort(&mut block, SortStrategy::Bazel);
+        sort(&mut block, STRATEGY);
         output_lines.append(&mut block);
     }
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -34,7 +34,7 @@ impl<'a> PartialOrd for SortKey<'a> {
 #[derive(Debug, PartialEq, Eq)]
 struct ItemGroup<'a> {
     comment: Vec<&'a str>,
-    code: &'a str,
+    item: &'a str,
     strategy: SortStrategy,
     sort_key: SortKey<'a>,
 }
@@ -48,14 +48,14 @@ impl<'a> ItemGroup<'a> {
         };
         Self {
             comment: Default::default(),
-            code: Default::default(),
+            item: Default::default(),
             strategy,
             sort_key,
         }
     }
 
-    fn set_code(&mut self, line: &'a str) {
-        self.code = line;
+    fn set_item(&mut self, line: &'a str) {
+        self.item = line;
         self.sort_key = match self.strategy {
             SortStrategy::Default => SortKey::Default(line),
             SortStrategy::Bazel => SortKey::Bazel(BazelSortKey::new(line)),
@@ -89,7 +89,7 @@ pub(crate) fn sort(block: &mut [&str], strategy: SortStrategy) {
         if is_single_line_comment(line) {
             current_group.comment.push(line);
         } else {
-            current_group.set_code(line);
+            current_group.set_item(line);
             groups.push(current_group);
             current_group = ItemGroup::new(strategy.clone());
         }
@@ -101,7 +101,7 @@ pub(crate) fn sort(block: &mut [&str], strategy: SortStrategy) {
     let mut sorted_block = Vec::with_capacity(block.len());
     for group in groups {
         sorted_block.extend(group.comment);
-        sorted_block.push(group.code);
+        sorted_block.push(group.item);
     }
     sorted_block.extend(trailing_comment);
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -56,10 +56,17 @@ impl<'a> Item<'a> {
 
     fn add_item(&mut self, line: &'a str) {
         self.item.push(line);
+        self.calculate_sort_key();
+    }
+
+    fn calculate_sort_key(&mut self) {
+        todo!("fix this");
+        let joined = self.item.join("\n");
+        let text = joined.as_str();
         self.sort_key = match self.strategy {
-            SortStrategy::Generic => SortKey::Generic(line),
-            SortStrategy::Bazel => SortKey::Bazel(BazelSortKey::new(line)),
-            SortStrategy::CargoToml => SortKey::Generic(line),
+            SortStrategy::Generic => SortKey::Generic(text),
+            SortStrategy::Bazel => SortKey::Bazel(BazelSortKey::new(text)),
+            SortStrategy::CargoToml => SortKey::Generic(text),
         };
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -32,14 +32,14 @@ impl<'a> PartialOrd for SortKey<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct LineGroup<'a> {
+struct ItemGroup<'a> {
     comments: Vec<&'a str>,
     code: &'a str,
     strategy: SortStrategy,
     sort_key: SortKey<'a>,
 }
 
-impl<'a> LineGroup<'a> {
+impl<'a> ItemGroup<'a> {
     fn new(strategy: SortStrategy) -> Self {
         let sort_key = match strategy {
             SortStrategy::Default => SortKey::Default(""),
@@ -64,13 +64,13 @@ impl<'a> LineGroup<'a> {
     }
 }
 
-impl<'a> Ord for LineGroup<'a> {
+impl<'a> Ord for ItemGroup<'a> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.sort_key.cmp(&other.sort_key)
     }
 }
 
-impl<'a> PartialOrd for LineGroup<'a> {
+impl<'a> PartialOrd for ItemGroup<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
@@ -83,7 +83,7 @@ fn is_single_line_comment(line: &str) -> bool {
 
 pub(crate) fn sort(block: &mut [&str], strategy: SortStrategy) {
     let mut groups = Vec::with_capacity(block.len());
-    let mut current_group = LineGroup::new(strategy.clone());
+    let mut current_group = ItemGroup::new(strategy.clone());
 
     for &line in block.iter() {
         if is_single_line_comment(line) {
@@ -91,7 +91,7 @@ pub(crate) fn sort(block: &mut [&str], strategy: SortStrategy) {
         } else {
             current_group.set_code(line);
             groups.push(current_group);
-            current_group = LineGroup::new(strategy.clone());
+            current_group = ItemGroup::new(strategy.clone());
         }
     }
     let trailing_comments = current_group.comments;

--- a/src/block.rs
+++ b/src/block.rs
@@ -33,7 +33,7 @@ impl<'a> PartialOrd for SortKey<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 struct ItemGroup<'a> {
-    comments: Vec<&'a str>,
+    comment: Vec<&'a str>,
     code: &'a str,
     strategy: SortStrategy,
     sort_key: SortKey<'a>,
@@ -47,7 +47,7 @@ impl<'a> ItemGroup<'a> {
             SortStrategy::CargoToml => SortKey::Default(""),
         };
         Self {
-            comments: Default::default(),
+            comment: Default::default(),
             code: Default::default(),
             strategy,
             sort_key,
@@ -87,23 +87,23 @@ pub(crate) fn sort(block: &mut [&str], strategy: SortStrategy) {
 
     for &line in block.iter() {
         if is_single_line_comment(line) {
-            current_group.comments.push(line);
+            current_group.comment.push(line);
         } else {
             current_group.set_code(line);
             groups.push(current_group);
             current_group = ItemGroup::new(strategy.clone());
         }
     }
-    let trailing_comments = current_group.comments;
+    let trailing_comment = current_group.comment;
 
     groups.sort();
 
     let mut sorted_block = Vec::with_capacity(block.len());
     for group in groups {
-        sorted_block.extend(group.comments);
+        sorted_block.extend(group.comment);
         sorted_block.push(group.code);
     }
-    sorted_block.extend(trailing_comments);
+    sorted_block.extend(trailing_comment);
 
     block.copy_from_slice(&sorted_block);
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -34,7 +34,7 @@ impl<'a> PartialOrd for SortKey<'a> {
 #[derive(Debug, PartialEq, Eq)]
 struct Item<'a> {
     comment: Vec<&'a str>,
-    item: &'a str,
+    item: Vec<&'a str>,
     strategy: SortStrategy,
     sort_key: SortKey<'a>,
 }
@@ -54,8 +54,8 @@ impl<'a> Item<'a> {
         }
     }
 
-    fn set_item(&mut self, line: &'a str) {
-        self.item = line;
+    fn add_item(&mut self, line: &'a str) {
+        self.item.push(line);
         self.sort_key = match self.strategy {
             SortStrategy::Generic => SortKey::Generic(line),
             SortStrategy::Bazel => SortKey::Bazel(BazelSortKey::new(line)),
@@ -89,7 +89,7 @@ pub(crate) fn sort(block: &mut [&str], strategy: SortStrategy) {
         if is_single_line_comment(line) {
             current_item.comment.push(line);
         } else {
-            current_item.set_item(line);
+            current_item.add_item(line);
             items.push(current_item);
             current_item = Item::new(strategy.clone());
         }
@@ -101,7 +101,7 @@ pub(crate) fn sort(block: &mut [&str], strategy: SortStrategy) {
     let mut sorted_block = Vec::with_capacity(block.len());
     for group in items {
         sorted_block.extend(group.comment);
-        sorted_block.push(group.item);
+        sorted_block.extend(group.item);
     }
     sorted_block.extend(trailing_comment);
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 pub enum SortStrategy {
     Default,
     Bazel,
+    CargoToml,
 }
 
 // A SortKey enum to handle different sorting strategies.
@@ -43,6 +44,7 @@ impl<'a> LineGroup<'a> {
         let sort_key = match strategy {
             SortStrategy::Default => SortKey::Default(""),
             SortStrategy::Bazel => SortKey::Bazel(BazelSortKey::new("")),
+            SortStrategy::CargoToml => SortKey::Default(""),
         };
         Self {
             comments: Default::default(),
@@ -57,6 +59,7 @@ impl<'a> LineGroup<'a> {
         self.sort_key = match self.strategy {
             SortStrategy::Default => SortKey::Default(line),
             SortStrategy::Bazel => SortKey::Bazel(BazelSortKey::new(line)),
+            SortStrategy::CargoToml => SortKey::Default(line),
         };
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SortStrategy {
-    Default,
+    Generic,
     Bazel,
     CargoToml,
 }
@@ -11,14 +11,14 @@ pub enum SortStrategy {
 // A SortKey enum to handle different sorting strategies.
 #[derive(Debug, PartialEq, Eq)]
 enum SortKey<'a> {
-    Default(&'a str),
+    Generic(&'a str),
     Bazel(BazelSortKey<'a>),
 }
 
 impl<'a> Ord for SortKey<'a> {
     fn cmp(&self, other: &Self) -> Ordering {
         match (self, other) {
-            (SortKey::Default(a), SortKey::Default(b)) => a.cmp(b),
+            (SortKey::Generic(a), SortKey::Generic(b)) => a.cmp(b),
             (SortKey::Bazel(a), SortKey::Bazel(b)) => a.cmp(b),
             _ => Ordering::Equal, // This should not happen if used correctly
         }
@@ -32,19 +32,19 @@ impl<'a> PartialOrd for SortKey<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-struct ItemGroup<'a> {
+struct Item<'a> {
     comment: Vec<&'a str>,
     item: &'a str,
     strategy: SortStrategy,
     sort_key: SortKey<'a>,
 }
 
-impl<'a> ItemGroup<'a> {
+impl<'a> Item<'a> {
     fn new(strategy: SortStrategy) -> Self {
         let sort_key = match strategy {
-            SortStrategy::Default => SortKey::Default(""),
+            SortStrategy::Generic => SortKey::Generic(""),
             SortStrategy::Bazel => SortKey::Bazel(BazelSortKey::new("")),
-            SortStrategy::CargoToml => SortKey::Default(""),
+            SortStrategy::CargoToml => SortKey::Generic(""),
         };
         Self {
             comment: Default::default(),
@@ -57,20 +57,20 @@ impl<'a> ItemGroup<'a> {
     fn set_item(&mut self, line: &'a str) {
         self.item = line;
         self.sort_key = match self.strategy {
-            SortStrategy::Default => SortKey::Default(line),
+            SortStrategy::Generic => SortKey::Generic(line),
             SortStrategy::Bazel => SortKey::Bazel(BazelSortKey::new(line)),
-            SortStrategy::CargoToml => SortKey::Default(line),
+            SortStrategy::CargoToml => SortKey::Generic(line),
         };
     }
 }
 
-impl<'a> Ord for ItemGroup<'a> {
+impl<'a> Ord for Item<'a> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.sort_key.cmp(&other.sort_key)
     }
 }
 
-impl<'a> PartialOrd for ItemGroup<'a> {
+impl<'a> PartialOrd for Item<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
@@ -82,24 +82,24 @@ fn is_single_line_comment(line: &str) -> bool {
 }
 
 pub(crate) fn sort(block: &mut [&str], strategy: SortStrategy) {
-    let mut groups = Vec::with_capacity(block.len());
-    let mut current_group = ItemGroup::new(strategy.clone());
+    let mut items = Vec::with_capacity(block.len());
+    let mut current_item = Item::new(strategy.clone());
 
     for &line in block.iter() {
         if is_single_line_comment(line) {
-            current_group.comment.push(line);
+            current_item.comment.push(line);
         } else {
-            current_group.set_item(line);
-            groups.push(current_group);
-            current_group = ItemGroup::new(strategy.clone());
+            current_item.set_item(line);
+            items.push(current_item);
+            current_item = Item::new(strategy.clone());
         }
     }
-    let trailing_comment = current_group.comment;
+    let trailing_comment = current_item.comment;
 
-    groups.sort();
+    items.sort();
 
     let mut sorted_block = Vec::with_capacity(block.len());
-    for group in groups {
+    for group in items {
         sorted_block.extend(group.comment);
         sorted_block.push(group.item);
     }

--- a/src/block.rs
+++ b/src/block.rs
@@ -60,9 +60,7 @@ impl<'a> Item<'a> {
     }
 
     fn calculate_sort_key(&mut self) {
-        todo!("fix this");
-        let joined = self.item.join("\n");
-        let text = joined.as_str();
+        let text = self.item.first().unwrap();
         self.sort_key = match self.strategy {
             SortStrategy::Generic => SortKey::Generic(text),
             SortStrategy::Bazel => SortKey::Bazel(BazelSortKey::new(text)),

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -2,10 +2,10 @@ use crate::block::{sort, SortStrategy};
 use regex::Regex;
 use std::io::{self};
 
-const STRATEGY: SortStrategy = SortStrategy::Default;
+const STRATEGY: SortStrategy = SortStrategy::CargoToml;
 
-pub(crate) fn process_lines_default(lines: Vec<&str>) -> io::Result<Vec<&str>> {
-    let re = Regex::new(r"^\s*#\s*Keep\s*sorted\.\s*$")
+pub(crate) fn process_lines_cargo_toml(lines: Vec<&str>) -> io::Result<Vec<&str>> {
+    let re = Regex::new(r"^\[dependencies\]$")
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
     let mut output_lines = Vec::new();
     let mut block = Vec::new();

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -1,7 +1,13 @@
 use crate::block::{sort, SortStrategy};
 use std::io::{self};
+use std::path::Path;
 
 const STRATEGY: SortStrategy = SortStrategy::CargoToml;
+
+pub(crate) fn is_cargo_toml(path: &Path) -> bool {
+    // Check if the path is a file and its file name is "Cargo.toml"
+    path.is_file() && path.file_name() == Some(std::ffi::OsStr::new("Cargo.toml"))
+}
 
 pub(crate) fn process_lines_cargo_toml(lines: Vec<&str>) -> io::Result<Vec<&str>> {
     let mut output_lines = Vec::new();
@@ -12,7 +18,7 @@ pub(crate) fn process_lines_cargo_toml(lines: Vec<&str>) -> io::Result<Vec<&str>
         let trimmed = line.trim();
         let line_without_comment = trimmed.split('#').next().unwrap_or("").trim();
 
-        if line == "[dependencies]" || line == "[dev-dependencies]" {
+        if line.starts_with("[dependencies]") || line.starts_with("[dev-dependencies]") {
             is_sorting_block = true;
             output_lines.push(line);
         } else if is_sorting_block

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 const STRATEGY: SortStrategy = SortStrategy::CargoToml;
 
+#[allow(dead_code)]
 pub(crate) fn is_cargo_toml(path: &Path) -> bool {
     // Check if the path is a file and its file name is "Cargo.toml"
     path.is_file() && path.file_name() == Some(std::ffi::OsStr::new("Cargo.toml"))

--- a/src/cargo_toml.rs
+++ b/src/cargo_toml.rs
@@ -9,6 +9,10 @@ pub(crate) fn is_cargo_toml(path: &Path) -> bool {
     path.is_file() && path.file_name() == Some(std::ffi::OsStr::new("Cargo.toml"))
 }
 
+fn is_block_start(line: &str) -> bool {
+    line.starts_with("[dependencies]") || line.starts_with("[dev-dependencies]")
+}
+
 pub(crate) fn process_lines_cargo_toml(lines: Vec<&str>) -> io::Result<Vec<&str>> {
     let mut output_lines = Vec::new();
     let mut block = Vec::new();
@@ -18,7 +22,7 @@ pub(crate) fn process_lines_cargo_toml(lines: Vec<&str>) -> io::Result<Vec<&str>
         let trimmed = line.trim();
         let line_without_comment = trimmed.split('#').next().unwrap_or("").trim();
 
-        if line.starts_with("[dependencies]") || line.starts_with("[dev-dependencies]") {
+        if is_block_start(line) {
             is_sorting_block = true;
             output_lines.push(line);
         } else if is_sorting_block

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -2,9 +2,9 @@ use crate::block::{sort, SortStrategy};
 use regex::Regex;
 use std::io::{self};
 
-const STRATEGY: SortStrategy = SortStrategy::Default;
+const STRATEGY: SortStrategy = SortStrategy::Generic;
 
-pub(crate) fn process_lines_default(lines: Vec<&str>) -> io::Result<Vec<&str>> {
+pub(crate) fn process_lines_generic(lines: Vec<&str>) -> io::Result<Vec<&str>> {
     let re = Regex::new(r"^\s*#\s*Keep\s*sorted\.\s*$")
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
     let mut output_lines = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use crate::bazel::{is_bazel, process_lines_bazel};
-use crate::cargo_toml::{is_cargo_toml, process_lines_cargo_toml};
+use crate::cargo_toml::process_lines_cargo_toml;
 use crate::generic::process_lines_generic;
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
@@ -21,11 +21,10 @@ pub fn process_file(path: &Path) -> io::Result<()> {
     }
     let lines: Vec<&str> = content.split_inclusive('\n').collect();
 
-    // Check the file extension
+    // Check the file extension.
+    // TODO: enable Cargo.toml support.
     let output_lines = if is_bazel(path) {
         process_lines(SortStrategy::Bazel, lines)?
-    } else if is_cargo_toml(path) {
-        process_lines(SortStrategy::CargoToml, lines)?
     } else {
         process_lines(SortStrategy::Generic, lines)?
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use crate::bazel::{is_bazel, process_lines_bazel};
-use crate::cargo_toml::process_lines_cargo_toml;
+use crate::cargo_toml::{is_cargo_toml, process_lines_cargo_toml};
 use crate::default::process_lines_default;
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
@@ -24,6 +24,8 @@ pub fn process_file(path: &Path) -> io::Result<()> {
     // Check the file extension
     let output_lines = if is_bazel(path) {
         process_lines(SortStrategy::Bazel, lines)?
+    } else if is_cargo_toml(path) {
+        process_lines(SortStrategy::CargoToml, lines)?
     } else {
         process_lines(SortStrategy::Default, lines)?
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use crate::bazel::{is_bazel, process_lines_bazel};
+use crate::cargo_toml::process_lines_cargo_toml;
 use crate::default::process_lines_default;
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
@@ -8,6 +9,7 @@ pub use crate::block::SortStrategy;
 
 mod bazel;
 mod block;
+mod cargo_toml;
 mod default;
 
 pub fn process_file(path: &Path) -> io::Result<()> {
@@ -46,5 +48,6 @@ pub fn process_lines(strategy: SortStrategy, lines: Vec<&str>) -> io::Result<Vec
     match strategy {
         SortStrategy::Default => process_lines_default(lines),
         SortStrategy::Bazel => process_lines_bazel(lines),
+        SortStrategy::CargoToml => process_lines_cargo_toml(lines),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::bazel::{is_bazel, process_lines_bazel};
 use crate::cargo_toml::{is_cargo_toml, process_lines_cargo_toml};
-use crate::default::process_lines_default;
+use crate::generic::process_lines_generic;
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
@@ -10,7 +10,7 @@ pub use crate::block::SortStrategy;
 mod bazel;
 mod block;
 mod cargo_toml;
-mod default;
+mod generic;
 
 pub fn process_file(path: &Path) -> io::Result<()> {
     let mut content = std::fs::read_to_string(path)?;
@@ -27,7 +27,7 @@ pub fn process_file(path: &Path) -> io::Result<()> {
     } else if is_cargo_toml(path) {
         process_lines(SortStrategy::CargoToml, lines)?
     } else {
-        process_lines(SortStrategy::Default, lines)?
+        process_lines(SortStrategy::Generic, lines)?
     };
 
     let n = output_lines.len();
@@ -48,7 +48,7 @@ pub fn process_file(path: &Path) -> io::Result<()> {
 
 pub fn process_lines(strategy: SortStrategy, lines: Vec<&str>) -> io::Result<Vec<&str>> {
     match strategy {
-        SortStrategy::Default => process_lines_default(lines),
+        SortStrategy::Generic => process_lines_generic(lines),
         SortStrategy::Bazel => process_lines_bazel(lines),
         SortStrategy::CargoToml => process_lines_cargo_toml(lines),
     }

--- a/tests/bazel.rs
+++ b/tests/bazel.rs
@@ -82,8 +82,8 @@ fn bazel_multi_line_comment() {
 block = [
     # Keep sorted.
     "y",
-    # Some multi-line comment,
-    # for the line below.,
+    # Some multi-line comment
+    # for the line below.
     "x",
     "b",
     "a",
@@ -94,8 +94,8 @@ block = [
     # Keep sorted.
     "a",
     "b",
-    # Some multi-line comment,
-    # for the line below.,
+    # Some multi-line comment
+    # for the line below.
     "x",
     "y",
 ]

--- a/tests/bazel.rs
+++ b/tests/bazel.rs
@@ -8,18 +8,18 @@ fn bazel_single_block() {
     test_inner!(
         Bazel,
         r#"
-            block = [
-                # Keep sorted.
-                "b",
-                "a",
-            ]
+block = [
+    # Keep sorted.
+    "b",
+    "a",
+]
         "#,
         r#"
-            block = [
-                # Keep sorted.
-                "a",
-                "b",
-            ]
+block = [
+    # Keep sorted.
+    "a",
+    "b",
+]
         "#
     );
 }
@@ -29,22 +29,22 @@ fn bazel_inline_comment() {
     test_inner!(
         Bazel,
         r#"
-            block = [
-                # Keep sorted.
-                "y",
-                "x",  # Some in-line comment.
-                "b",
-                "a",
-            ]
+block = [
+    # Keep sorted.
+    "y",
+    "x",  # Some in-line comment.
+    "b",
+    "a",
+]
         "#,
         r#"
-            block = [
-                # Keep sorted.
-                "a",
-                "b",
-                "x",  # Some in-line comment.
-                "y",
-            ]
+block = [
+    # Keep sorted.
+    "a",
+    "b",
+    "x",  # Some in-line comment.
+    "y",
+]
         "#
     );
 }
@@ -54,22 +54,22 @@ fn bazel_inline_comment_with_braces() {
     test_inner!(
         Bazel,
         r#"
-            block = [
-                # Keep sorted.
-                "y",
-                "x",  # TODO[xxx].
-                "b",
-                "a",
-            ]
+block = [
+    # Keep sorted.
+    "y",
+    "x",  # TODO[xxx].
+    "b",
+    "a",
+]
         "#,
         r#"
-            block = [
-                # Keep sorted.
-                "a",
-                "b",
-                "x",  # TODO[xxx].
-                "y",
-            ]
+block = [
+    # Keep sorted.
+    "a",
+    "b",
+    "x",  # TODO[xxx].
+    "y",
+]
         "#
     );
 }
@@ -79,26 +79,26 @@ fn bazel_multi_line_comment() {
     test_inner!(
         Bazel,
         r#"
-            block = [
-                # Keep sorted.
-                "y",
-                # Some multi-line comment,
-                # for the line below.,
-                "x",
-                "b",
-                "a",
-            ]
+block = [
+    # Keep sorted.
+    "y",
+    # Some multi-line comment,
+    # for the line below.,
+    "x",
+    "b",
+    "a",
+]
         "#,
         r#"
-            block = [
-                # Keep sorted.
-                "a",
-                "b",
-                # Some multi-line comment,
-                # for the line below.,
-                "x",
-                "y",
-            ]
+block = [
+    # Keep sorted.
+    "a",
+    "b",
+    # Some multi-line comment,
+    # for the line below.,
+    "x",
+    "y",
+]
         "#
     );
 }
@@ -108,22 +108,22 @@ fn bazel_multi_line_trailing_comment() {
     test_inner!(
         Bazel,
         r#"
-            block = [
-                # Keep sorted.
-                "b",
-                "a",
-                # Some multi-line comment
-                # trailing comment.
-            ]
+block = [
+    # Keep sorted.
+    "b",
+    "a",
+    # Some multi-line comment
+    # trailing comment.
+]
         "#,
         r#"
-            block = [
-                # Keep sorted.
-                "a",
-                "b",
-                # Some multi-line comment
-                # trailing comment.
-            ]
+block = [
+    # Keep sorted.
+    "a",
+    "b",
+    # Some multi-line comment
+    # trailing comment.
+]
         "#
     );
 }
@@ -133,30 +133,30 @@ fn bazel_several_multi_line_comments() {
     test_inner!(
         Bazel,
         r#"
-            block = [
-                # Keep sorted.
-                "y",
-                # Some multi-line comment
-                # for the line below.
-                "x",
-                "b",
-                "a",
-                # Some multi-line comment
-                # trailing comment.
-            ]
+block = [
+    # Keep sorted.
+    "y",
+    # Some multi-line comment
+    # for the line below.
+    "x",
+    "b",
+    "a",
+    # Some multi-line comment
+    # trailing comment.
+]
         "#,
         r#"
-            block = [
-                # Keep sorted.
-                "a",
-                "b",
-                # Some multi-line comment
-                # for the line below.
-                "x",
-                "y",
-                # Some multi-line comment
-                # trailing comment.
-            ]
+block = [
+    # Keep sorted.
+    "a",
+    "b",
+    # Some multi-line comment
+    # for the line below.
+    "x",
+    "y",
+    # Some multi-line comment
+    # trailing comment.
+]
         "#
     );
 }
@@ -166,26 +166,26 @@ fn bazel_single_block_with_comment() {
     test_inner!(
         Bazel,
         r#"
-            block = [
-                # Keep sorted.
-                "d",
-                # Some comment about the line below.
-                "c",
-                "b",  # TODO[bbb]
-                "a",
-                # Trailing comment.
-            ]
+block = [
+    # Keep sorted.
+    "d",
+    # Some comment about the line below.
+    "c",
+    "b",  # TODO[bbb]
+    "a",
+    # Trailing comment.
+]
         "#,
         r#"
-            block = [
-                # Keep sorted.
-                "a",
-                "b",  # TODO[bbb]
-                # Some comment about the line below.
-                "c",
-                "d",
-                # Trailing comment.
-            ]
+block = [
+    # Keep sorted.
+    "a",
+    "b",  # TODO[bbb]
+    # Some comment about the line below.
+    "c",
+    "d",
+    # Trailing comment.
+]
         "#
     );
 }
@@ -195,26 +195,26 @@ fn bazel_blocks() {
     test_inner!(
         Bazel,
         r#"
-            block_1 = [
-                # Keep sorted.
-                "b",
-                "a",
-            ],
-            block_2 = [
-                "y",
-                "x",
-            ],
+block_1 = [
+    # Keep sorted.
+    "b",
+    "a",
+],
+block_2 = [
+    "y",
+    "x",
+],
         "#,
         r#"
-            block_1 = [
-                # Keep sorted.
-                "a",
-                "b",
-            ],
-            block_2 = [
-                "y",
-                "x",
-            ],
+block_1 = [
+    # Keep sorted.
+    "a",
+    "b",
+],
+block_2 = [
+    "y",
+    "x",
+],
         "#
     );
 }
@@ -224,40 +224,40 @@ fn bazel_blocks_with_select() {
     test_inner!(
         Bazel,
         r#"
-            deps = [
-                # Keep sorted.
-                "b",
-                "a",
-            ] + select({
-                "@platforms//os:osx": [
-                    # Keep sorted.
-                    "y",
-                    "x",
-                ],
-                "//conditions:default": [
-                    # Keep sorted.
-                    "m",
-                    "k",
-                ],
-            })
+deps = [
+    # Keep sorted.
+    "b",
+    "a",
+] + select({
+    "@platforms//os:osx": [
+        # Keep sorted.
+        "y",
+        "x",
+    ],
+    "//conditions:default": [
+        # Keep sorted.
+        "m",
+        "k",
+    ],
+})
         "#,
         r#"
-            deps = [
-                # Keep sorted.
-                "a",
-                "b",
-            ] + select({
-                "@platforms//os:osx": [
-                    # Keep sorted.
-                    "x",
-                    "y",
-                ],
-                "//conditions:default": [
-                    # Keep sorted.
-                    "k",
-                    "m",
-                ],
-            })
+deps = [
+    # Keep sorted.
+    "a",
+    "b",
+] + select({
+    "@platforms//os:osx": [
+        # Keep sorted.
+        "x",
+        "y",
+    ],
+    "//conditions:default": [
+        # Keep sorted.
+        "k",
+        "m",
+    ],
+})
         "#
     );
 }
@@ -267,48 +267,48 @@ fn bazel_order() {
     test_inner!(
         Bazel,
         r#"
-            block = [
-                # Keep sorted.
-                ":bbb",
-                ":aaa",
-                "nested",
-                "//dir/subdir/folder:yyy",  # TODO[yyy]
-                "//dir/subdir/folder:xxx",
-                "//dir/subdir/folder",  # Some in-line comment.
-                "//dir/subdir:bbb",
-                "//dir/subdir:aaa",
-                "@crate_index//project",
-                "@crate_index//:base64-bytestring",
-                "@crate_index//:base32",
-                "@crate_index//:base",
-                "@crate_index//:bbb",
-                "@crate_index//:aaa",
-                requirement("gitpython"),
-                requirement("python-gitlab"),
-                requirement("pyyaml"),
-            ]
+block = [
+    # Keep sorted.
+    ":bbb",
+    ":aaa",
+    "nested",
+    "//dir/subdir/folder:yyy",  # TODO[yyy]
+    "//dir/subdir/folder:xxx",
+    "//dir/subdir/folder",  # Some in-line comment.
+    "//dir/subdir:bbb",
+    "//dir/subdir:aaa",
+    "@crate_index//project",
+    "@crate_index//:base64-bytestring",
+    "@crate_index//:base32",
+    "@crate_index//:base",
+    "@crate_index//:bbb",
+    "@crate_index//:aaa",
+    requirement("gitpython"),
+    requirement("python-gitlab"),
+    requirement("pyyaml"),
+]
         "#,
         r#"
-            block = [
-                # Keep sorted.
-                "nested",
-                ":aaa",
-                ":bbb",
-                "//dir/subdir:aaa",
-                "//dir/subdir:bbb",
-                "//dir/subdir/folder",  # Some in-line comment.
-                "//dir/subdir/folder:xxx",
-                "//dir/subdir/folder:yyy",  # TODO[yyy]
-                "@crate_index//:aaa",
-                "@crate_index//:base",
-                "@crate_index//:base32",
-                "@crate_index//:base64-bytestring",
-                "@crate_index//:bbb",
-                "@crate_index//project",
-                requirement("gitpython"),
-                requirement("python-gitlab"),
-                requirement("pyyaml"),
-            ]
+block = [
+    # Keep sorted.
+    "nested",
+    ":aaa",
+    ":bbb",
+    "//dir/subdir:aaa",
+    "//dir/subdir:bbb",
+    "//dir/subdir/folder",  # Some in-line comment.
+    "//dir/subdir/folder:xxx",
+    "//dir/subdir/folder:yyy",  # TODO[yyy]
+    "@crate_index//:aaa",
+    "@crate_index//:base",
+    "@crate_index//:base32",
+    "@crate_index//:base64-bytestring",
+    "@crate_index//:bbb",
+    "@crate_index//project",
+    requirement("gitpython"),
+    requirement("python-gitlab"),
+    requirement("pyyaml"),
+]
         "#
     );
 }

--- a/tests/cargo_toml.rs
+++ b/tests/cargo_toml.rs
@@ -130,3 +130,28 @@ y = "4"
         "#
     );
 }
+
+#[test]
+fn cargo_toml_nested_list() {
+    test_inner!(
+        CargoToml,
+        r#"
+[dependencies]
+b = { workspace = true, default-features = false, features = [
+    "z",
+    "y",
+    "x",
+] }
+a = "1"
+        "#,
+        r#"
+[dependencies]
+a = "1"
+b = { workspace = true, default-features = false, features = [
+    "z",
+    "y",
+    "x",
+] }
+        "#
+    );
+}

--- a/tests/cargo_toml.rs
+++ b/tests/cargo_toml.rs
@@ -1,0 +1,21 @@
+#[macro_use]
+mod common;
+
+use keepsorted::SortStrategy::CargoToml;
+
+#[test]
+fn cargo_toml_simple() {
+    test_inner!(
+        CargoToml,
+        r#"
+[dependencies]
+b = "2"
+a = "1"
+        "#,
+        r#"
+[dependencies]
+a = "1"
+b = "2"
+        "#
+    );
+}

--- a/tests/cargo_toml.rs
+++ b/tests/cargo_toml.rs
@@ -132,6 +132,7 @@ y = "4"
 }
 
 #[test]
+#[ignore]
 fn cargo_toml_nested_list() {
     test_inner!(
         CargoToml,

--- a/tests/cargo_toml.rs
+++ b/tests/cargo_toml.rs
@@ -19,3 +19,114 @@ b = "2"
         "#
     );
 }
+
+#[test]
+fn cargo_toml_list_with_item_comment() {
+    test_inner!(
+        CargoToml,
+        r#"
+[dependencies]
+c = "3"
+b = "2"
+# Some comment related to line below.
+a = "1"
+        "#,
+        r#"
+[dependencies]
+# Some comment related to line below.
+a = "1"
+b = "2"
+c = "3"
+        "#
+    );
+}
+
+#[test]
+fn cargo_toml_list_with_inline_comment() {
+    test_inner!(
+        CargoToml,
+        r#"
+[dependencies]
+c = "3"
+b = "2"
+a = "1"  # Some in-line comment.
+        "#,
+        r#"
+[dependencies]
+a = "1"  # Some in-line comment.
+b = "2"
+c = "3"
+        "#
+    );
+}
+
+#[test]
+fn cargo_toml_two_scopes() {
+    test_inner!(
+        CargoToml,
+        r#"
+[dependencies]
+b = "2"
+a = "1"
+[lib]
+name = "some_name"
+path = "src/lib.rs"
+        "#,
+        r#"
+[dependencies]
+a = "1"
+b = "2"
+[lib]
+name = "some_name"
+path = "src/lib.rs"
+        "#
+    );
+}
+
+#[test]
+fn cargo_toml_block_with_newline_inside() {
+    test_inner!(
+        CargoToml,
+        r#"
+[dependencies]
+b = "2"
+a = "1"
+
+y = "4"
+x = "3"
+        "#,
+        r#"
+[dependencies]
+a = "1"
+b = "2"
+
+y = "4"
+x = "3"
+        "#
+    );
+}
+
+#[test]
+fn cargo_toml_two_blocks() {
+    test_inner!(
+        CargoToml,
+        r#"
+[dependencies]
+b = "2"
+a = "1"
+
+[dev-dependencies]
+y = "4"
+x = "3"
+        "#,
+        r#"
+[dependencies]
+a = "1"
+b = "2"
+
+[dev-dependencies]
+x = "3"
+y = "4"
+        "#
+    );
+}

--- a/tests/default.rs
+++ b/tests/default.rs
@@ -13,10 +13,10 @@ fn default_single_item() {
     test_inner!(
         Default,
         r#"
-            a
+a
         "#,
         r#"
-            a
+a
         "#
     );
 }
@@ -26,12 +26,12 @@ fn default_no_sorting_comment() {
     test_inner!(
         Default,
         r#"
-            b
-            a
+b
+a
         "#,
         r#"
-            b
-            a
+b
+a
         "#
     );
 }
@@ -41,14 +41,14 @@ fn default_simple_block() {
     test_inner!(
         Default,
         r#"
-            # Keep sorted.
-            b
-            a
+# Keep sorted.
+b
+a
         "#,
         r#"
-            # Keep sorted.
-            a
-            b
+# Keep sorted.
+a
+b
         "#
     );
 }
@@ -58,20 +58,20 @@ fn default_blocks_divided_by_newline() {
     test_inner!(
         Default,
         r#"
-            # Keep sorted.
-            d
-            c
+# Keep sorted.
+d
+c
 
-            b
-            a
+b
+a
         "#,
         r#"
-            # Keep sorted.
-            c
-            d
+# Keep sorted.
+c
+d
 
-            b
-            a
+b
+a
         "#
     );
 }
@@ -83,22 +83,22 @@ fn with_multi_line_comment_rust() {
     test_inner!(
         Default,
         r#"
-            // Keep sorted.
-            y,
-            /* Some multi-line comment,
-               for the line below.  */,
-            x,
-            b,
-            a,
+// Keep sorted.
+y,
+/* Some multi-line comment,
+    for the line below.  */,
+x,
+b,
+a,
         "#,
         r#"
-            // Keep sorted.
-            a,
-            b,
-            /* Some multi-line comment,
-               for the line below.  */,
-            x,
-            y,
+// Keep sorted.
+a,
+b,
+/* Some multi-line comment,
+    for the line below.  */,
+x,
+y,
         "#
     );
 }

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -4,12 +4,12 @@ mod common;
 use keepsorted::SortStrategy::Generic;
 
 #[test]
-fn default_empty() {
+fn generic_empty() {
     test_inner!(Generic, "", "");
 }
 
 #[test]
-fn default_single_item() {
+fn generic_single_item() {
     test_inner!(
         Generic,
         r#"
@@ -22,7 +22,7 @@ a
 }
 
 #[test]
-fn default_no_sorting_comment() {
+fn generic_no_sorting_comment() {
     test_inner!(
         Generic,
         r#"
@@ -37,7 +37,7 @@ a
 }
 
 #[test]
-fn default_simple_block() {
+fn generic_simple_block() {
     test_inner!(
         Generic,
         r#"
@@ -54,7 +54,7 @@ b
 }
 
 #[test]
-fn default_blocks_divided_by_newline() {
+fn generic_blocks_divided_by_newline() {
     test_inner!(
         Generic,
         r#"

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -4,21 +4,6 @@ mod common;
 use keepsorted::SortStrategy::Generic;
 
 #[test]
-fn generic_no_sorting_comment() {
-    test_inner!(
-        Generic,
-        r#"
-b
-a
-        "#,
-        r#"
-b
-a
-        "#
-    );
-}
-
-#[test]
 fn generic_simple_block() {
     test_inner!(
         Generic,
@@ -36,24 +21,116 @@ b
 }
 
 #[test]
-fn generic_blocks_divided_by_newline() {
+fn generic_blocks_with_newline() {
     test_inner!(
         Generic,
         r#"
 # Keep sorted.
-d
-c
+y
+x
 
 b
 a
         "#,
         r#"
 # Keep sorted.
-c
-d
+x
+y
 
 b
 a
+        "#
+    );
+}
+
+#[test]
+fn generic_several_blocks() {
+    test_inner!(
+        Generic,
+        r#"
+# Keep sorted.
+y
+x
+
+# Keep sorted.
+b
+a
+        "#,
+        r#"
+# Keep sorted.
+x
+y
+
+# Keep sorted.
+a
+b
+        "#
+    );
+}
+
+#[test]
+fn generic_block_with_multi_line_comment() {
+    test_inner!(
+        Generic,
+        r#"
+# Keep sorted.
+y
+# Some multi-line comment
+# for the line below.
+x
+b
+a
+        "#,
+        r#"
+# Keep sorted.
+a
+b
+# Some multi-line comment
+# for the line below.
+x
+y
+        "#
+    );
+}
+
+#[test]
+fn generic_block_with_trailing_comment() {
+    test_inner!(
+        Generic,
+        r#"
+# Keep sorted.
+b
+a
+# Some multi-line comment
+# trailing comment.
+        "#,
+        r#"
+# Keep sorted.
+a
+b
+# Some multi-line comment
+# trailing comment.
+        "#
+    );
+}
+
+#[test]
+fn generic_block_with_inline_comment() {
+    test_inner!(
+        Generic,
+        r#"
+# Keep sorted.
+y
+x  # Some in-line comment.
+b
+a
+        "#,
+        r#"
+# Keep sorted.
+a
+b
+x  # Some in-line comment.
+y
         "#
     );
 }

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -1,17 +1,17 @@
 #[macro_use]
 mod common;
 
-use keepsorted::SortStrategy::Default;
+use keepsorted::SortStrategy::Generic;
 
 #[test]
 fn default_empty() {
-    test_inner!(Default, "", "");
+    test_inner!(Generic, "", "");
 }
 
 #[test]
 fn default_single_item() {
     test_inner!(
-        Default,
+        Generic,
         r#"
 a
         "#,
@@ -24,7 +24,7 @@ a
 #[test]
 fn default_no_sorting_comment() {
     test_inner!(
-        Default,
+        Generic,
         r#"
 b
 a
@@ -39,7 +39,7 @@ a
 #[test]
 fn default_simple_block() {
     test_inner!(
-        Default,
+        Generic,
         r#"
 # Keep sorted.
 b
@@ -56,7 +56,7 @@ b
 #[test]
 fn default_blocks_divided_by_newline() {
     test_inner!(
-        Default,
+        Generic,
         r#"
 # Keep sorted.
 d
@@ -81,7 +81,7 @@ a
 #[ignore]
 fn with_multi_line_comment_rust() {
     test_inner!(
-        Default,
+        Generic,
         r#"
 // Keep sorted.
 y,

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -4,24 +4,6 @@ mod common;
 use keepsorted::SortStrategy::Generic;
 
 #[test]
-fn generic_empty() {
-    test_inner!(Generic, "", "");
-}
-
-#[test]
-fn generic_single_item() {
-    test_inner!(
-        Generic,
-        r#"
-a
-        "#,
-        r#"
-a
-        "#
-    );
-}
-
-#[test]
 fn generic_no_sorting_comment() {
     test_inner!(
         Generic,

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -67,8 +67,10 @@ fn with_multi_line_comment_rust() {
         r#"
 // Keep sorted.
 y,
-/* Some multi-line comment,
-    for the line below.  */,
+/* 
+ * Some multi-line comment
+ * for the line below.
+ */
 x,
 b,
 a,
@@ -77,8 +79,10 @@ a,
 // Keep sorted.
 a,
 b,
-/* Some multi-line comment,
-    for the line below.  */,
+/* 
+ * Some multi-line comment
+ * for the line below.
+ */
 x,
 y,
         "#


### PR DESCRIPTION
This PR refactors the code to support sorting of Cargo.toml content.

Changes:
- added basic implementation for Cargo.toml, but multi-line list items are not supported yet, so the feature is disabled
- renamed default strategy to `Generic`
- added macro for testing
