### PR TITLE
feat: enable Cargo.toml support by default and delete feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ fn classify(path: &Path, features: Vec<String>) -> Strategy {
     if is_bazel(path) {
         return Strategy::Bazel;
     }
-    if features.contains(&"cargo_toml".to_string()) && is_cargo_toml(path) {
+    if is_cargo_toml(path) {
         return Strategy::CargoToml;
     }
     if features.contains(&"gitignore".to_string()) && is_gitignore(path) {

--- a/src/strategies/cargo_toml.rs
+++ b/src/strategies/cargo_toml.rs
@@ -35,7 +35,24 @@ pub(crate) fn process(lines: Vec<String>) -> io::Result<Vec<String>> {
 }
 
 fn is_block_start(line: &str) -> bool {
-    line.starts_with("[dependencies]") || line.starts_with("[dev-dependencies]")
+    // Check if the line starts and ends with brackets.
+    let trimmed = line.trim();
+    if !trimmed.starts_with('[') || !trimmed.ends_with(']') {
+        return false;
+    }
+    for case in ["dependencies", "dev-dependencies", "build-dependencies"] {
+        let patterns = [
+            format!("[{case}]"),           // E.g. [dependencies]
+            format!(".{case}]"),           // E.g. [xxx.dev-dependencies]
+            format!("[{case}."),           // E.g. [dev-dependencies.xxx]
+            format!("[workspace.{case}."), // E.g. [workspace.dependencies.xxx]
+        ];
+        if patterns.iter().any(|pattern| trimmed.contains(pattern)) {
+            return true;
+        }
+    }
+
+    false
 }
 
 #[derive(Default)]

--- a/tests/e2e-tests.rs
+++ b/tests/e2e-tests.rs
@@ -90,7 +90,7 @@ fn test_e2e_cargo_toml_1() {
     run_test(
         &dir("cargo_toml/1/Cargo.toml"),
         &dir("cargo_toml/1/Cargo_out.toml"),
-        "cargo_toml",
+        "",
     );
 }
 
@@ -99,7 +99,7 @@ fn test_e2e_cargo_toml_2() {
     run_test(
         &dir("cargo_toml/2/Cargo.toml"),
         &dir("cargo_toml/2/Cargo_out.toml"),
-        "cargo_toml",
+        "",
     );
 }
 


### PR DESCRIPTION
This PR enables `Cargo.toml` support by default and removes corresponding feature flag.