### PR TITLE
chore: add an example for rust derive trait order 

### DIFF
--- a/research/derive_order/Cargo.toml
+++ b/research/derive_order/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "derive_macros",
+    "use_macros",
+]

--- a/research/derive_order/README.md
+++ b/research/derive_order/README.md
@@ -1,0 +1,34 @@
+# Rust Derive Order Example
+
+This project shows how the order of Rust derive traits can impact a struct's behavior. 
+It includes two custom procedural macros `First` and `Second`.
+
+## Structure
+
+- **derive_macros/**: Defines the `First` and `Second` macros
+- **use_macros/**: Contains tests to verify the behavior of the macros
+
+## Tests
+
+Two tests demonstrate the importance of derive order:
+
+1. **`test_first_second`**: `First` is derived before `Second`. This should pass.
+2. **`test_second_first`**: `Second` is derived before `First`. This may fail, but it actually passes. **Seems like the derive order does not matter!**
+
+### Run Tests
+
+To run the tests:
+
+```shell
+cargo test -p use_macros -- --nocapture
+```
+
+Output:
+
+```shell
+running 2 tests
+First is implemented, so Second works!
+First is implemented, so Second works!
+test tests::test_second_first ... ok
+test tests::test_first_second ... ok
+```

--- a/research/derive_order/derive_macros/Cargo.toml
+++ b/research/derive_order/derive_macros/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-syn = "2.0"
-quote = "1.0"
 proc-macro2 = "1.0"
+quote = "1.0"
+syn = "2.0"

--- a/research/derive_order/derive_macros/Cargo.toml
+++ b/research/derive_order/derive_macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "derive_macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2.0"
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/research/derive_order/derive_macros/src/lib.rs
+++ b/research/derive_order/derive_macros/src/lib.rs
@@ -1,0 +1,42 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(First)]
+pub fn derive_first(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let name = &ast.ident;
+    
+    let expanded = quote! {
+        impl First for #name {
+            fn is_first_implemented() -> bool {
+                true
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(Second)]
+pub fn derive_second(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let name = &ast.ident;
+
+    let expanded = quote! {
+        impl Second for #name {
+            fn check_first_is_implemented() -> bool {
+                if <#name as First>::is_first_implemented() {
+                    println!("First is implemented, so Second works!");
+                    true
+                } else {
+                    println!("First is NOT implemented, so Second fails!");
+                    false
+                }
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/research/derive_order/derive_macros/src/lib.rs
+++ b/research/derive_order/derive_macros/src/lib.rs
@@ -5,38 +5,32 @@ use syn::{parse_macro_input, DeriveInput};
 
 #[proc_macro_derive(First)]
 pub fn derive_first(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-    let name = &ast.ident;
+    let name = parse_macro_input!(input as DeriveInput).ident;
     
-    let expanded = quote! {
+    TokenStream::from(quote! {
         impl First for #name {
             fn is_first_implemented() -> bool {
                 true
             }
         }
-    };
-
-    TokenStream::from(expanded)
+    })
 }
 
 #[proc_macro_derive(Second)]
 pub fn derive_second(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-    let name = &ast.ident;
+    let name = parse_macro_input!(input as DeriveInput).ident;
 
-    let expanded = quote! {
+    TokenStream::from(quote! {
         impl Second for #name {
             fn check_first_is_implemented() -> bool {
-                if <#name as First>::is_first_implemented() {
-                    println!("First is implemented, so Second works!");
-                    true
-                } else {
-                    println!("First is NOT implemented, so Second fails!");
-                    false
-                }
+                let result = <#name as First>::is_first_implemented();
+                println!(
+                    "First is {}implemented, so Second {}!",
+                    if result { "" } else { "NOT " },
+                    if result { "works" } else { "fails" }
+                );
+                result
             }
         }
-    };
-
-    TokenStream::from(expanded)
+    })
 }

--- a/research/derive_order/use_macros/Cargo.toml
+++ b/research/derive_order/use_macros/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "use_macros"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+derive_macros = { path = "../derive_macros" }

--- a/research/derive_order/use_macros/src/lib.rs
+++ b/research/derive_order/use_macros/src/lib.rs
@@ -1,0 +1,28 @@
+#[cfg(test)]
+mod tests {
+    use derive_macros::{First, Second};
+
+    trait First {
+        fn is_first_implemented() -> bool;
+    }
+
+    trait Second {
+        fn check_first_is_implemented() -> bool;
+    }
+
+    #[test]
+    fn test_first_second() {
+        #[derive(First, Second)] // <-- This should work correctly.
+        struct MyStruct;
+
+        assert!(<MyStruct as Second>::check_first_is_implemented());
+    }
+
+    #[test]
+    fn test_second_first() {
+        #[derive(Second, First)] // <-- Clarify if this should work or fail.
+        struct MyStruct;
+
+        assert!(<MyStruct as Second>::check_first_is_implemented());
+    }
+}

--- a/research/derive_order/use_macros/src/lib.rs
+++ b/research/derive_order/use_macros/src/lib.rs
@@ -20,6 +20,7 @@ mod tests {
 
     #[test]
     fn test_second_first() {
+        // keepsorted: ignore block
         #[derive(Second, First)] // <- Seems the order is not important.
         struct MyStruct;
 

--- a/research/derive_order/use_macros/src/lib.rs
+++ b/research/derive_order/use_macros/src/lib.rs
@@ -12,7 +12,7 @@ mod tests {
 
     #[test]
     fn test_first_second() {
-        #[derive(First, Second)]
+        #[derive(First, Second)] // <- This is expected to work.
         struct MyStruct;
 
         assert!(MyStruct::check_first_is_implemented());

--- a/research/derive_order/use_macros/src/lib.rs
+++ b/research/derive_order/use_macros/src/lib.rs
@@ -12,17 +12,17 @@ mod tests {
 
     #[test]
     fn test_first_second() {
-        #[derive(First, Second)] // <-- This should work correctly.
+        #[derive(First, Second)]
         struct MyStruct;
 
-        assert!(<MyStruct as Second>::check_first_is_implemented());
+        assert!(MyStruct::check_first_is_implemented());
     }
 
     #[test]
     fn test_second_first() {
-        #[derive(Second, First)] // <-- Clarify if this should work or fail.
+        #[derive(Second, First)]
         struct MyStruct;
 
-        assert!(<MyStruct as Second>::check_first_is_implemented());
+        assert!(MyStruct::check_first_is_implemented());
     }
 }

--- a/research/derive_order/use_macros/src/lib.rs
+++ b/research/derive_order/use_macros/src/lib.rs
@@ -1,3 +1,5 @@
+// This test file checks if the order of Rust derive traits matters.
+// Since the keepsorted tool could reorder these traits in CI, we must ignore this file.
 // keepsorted: ignore file
 
 #[cfg(test)]
@@ -14,7 +16,7 @@ mod tests {
 
     #[test]
     fn test_first_second() {
-        #[derive(First, Second)] // <- This is expected to work.
+        #[derive(First, Second)] // <- This order should work.
         struct MyStruct;
 
         assert!(MyStruct::check_first_is_implemented());
@@ -22,7 +24,7 @@ mod tests {
 
     #[test]
     fn test_second_first() {
-        #[derive(Second, First)] // <- Seems the order is not important.
+        #[derive(Second, First)] // <- This order might not work.
         struct MyStruct;
 
         assert!(MyStruct::check_first_is_implemented());

--- a/research/derive_order/use_macros/src/lib.rs
+++ b/research/derive_order/use_macros/src/lib.rs
@@ -20,7 +20,7 @@ mod tests {
 
     #[test]
     fn test_second_first() {
-        #[derive(Second, First)]
+        #[derive(Second, First)] // <- Seems the order is not important.
         struct MyStruct;
 
         assert!(MyStruct::check_first_is_implemented());

--- a/research/derive_order/use_macros/src/lib.rs
+++ b/research/derive_order/use_macros/src/lib.rs
@@ -12,6 +12,7 @@ mod tests {
 
     #[test]
     fn test_first_second() {
+        // keepsorted: ignore block
         #[derive(First, Second)] // <- This is expected to work.
         struct MyStruct;
 

--- a/research/derive_order/use_macros/src/lib.rs
+++ b/research/derive_order/use_macros/src/lib.rs
@@ -1,3 +1,5 @@
+// keepsorted: ignore file
+
 #[cfg(test)]
 mod tests {
     use derive_macros::{First, Second};
@@ -12,7 +14,6 @@ mod tests {
 
     #[test]
     fn test_first_second() {
-        // keepsorted: ignore block
         #[derive(First, Second)] // <- This is expected to work.
         struct MyStruct;
 
@@ -21,7 +22,6 @@ mod tests {
 
     #[test]
     fn test_second_first() {
-        // keepsorted: ignore block
         #[derive(Second, First)] // <- Seems the order is not important.
         struct MyStruct;
 


### PR DESCRIPTION
This PR introduces a project testing the importance of the order in which Rust derive traits are applied. 

It includes:
- Custom procedural macros `First` and `Second`
- Tests to validate behavior with different derive orders

Notes:
- The keepsorted tool is ignored on a test file to avoid automatic reordering of derive traits.