### PR TITLE
fix: parsing derive block

### DIFF
--- a/src/strategies/rust_derive.rs
+++ b/src/strategies/rust_derive.rs
@@ -66,14 +66,10 @@ fn sort(block: Vec<String>, is_ignore_block_prev_line: bool, strategy: Strategy)
     let line_without_comment = line.trim().split("//").next().unwrap_or("").trim();
 
     // Check if the line contains a #[derive(...)] statement
-    if let Some(derive_range) = line_without_comment
-        .find("#[derive(")
-        .map(|start| {
-            let end = line_without_comment[start..].find(")]")?;
-            Some(start + 9..start + end)
-        })
-        .flatten()
-    {
+    if let Some(derive_range) = line_without_comment.find("#[derive(").and_then(|start| {
+        let end = line_without_comment[start..].find(")]")?;
+        Some(start + 9..start + end)
+    }) {
         let derive_content = &line_without_comment[derive_range.clone()];
         let mut traits: Vec<&str> = derive_content
             .split(',')

--- a/tests/rust_derive.rs
+++ b/tests/rust_derive.rs
@@ -241,3 +241,20 @@ struct Data {}
         "#
     );
 }
+
+#[test]
+fn rust_derive_issue_25() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+#[derive(Parser, Debug)] // Some comment.
+#[command(about = "description", long_about = None)]
+struct Data {}
+        "#,
+        r#"
+#[derive(Debug, Parser)] // Some comment.
+#[command(about = "description", long_about = None)]
+struct Data {}
+        "#
+    );
+}

--- a/tests/rust_derive.rs
+++ b/tests/rust_derive.rs
@@ -243,7 +243,22 @@ struct Data {}
 }
 
 #[test]
-fn rust_derive_issue_25() {
+fn rust_derive_issue_25_1() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+#[derive(Parser, Debug)] // Some comment.
+struct Data {}
+        "#,
+        r#"
+#[derive(Debug, Parser)] // Some comment.
+struct Data {}
+        "#
+    );
+}
+
+#[test]
+fn rust_derive_issue_25_2() {
     test_inner!(
         RustDeriveAlphabetical,
         r#"
@@ -253,6 +268,23 @@ struct Data {}
         "#,
         r#"
 #[derive(Debug, Parser)] // Some comment.
+#[command(about = "description", long_about = None)]
+struct Data {}
+        "#
+    );
+}
+
+#[test]
+fn rust_derive_issue_25_3() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+#[derive(Parser, Debug)] // Some comment comment with #[derive(Parser, Debug)].
+#[command(about = "description", long_about = None)]
+struct Data {}
+        "#,
+        r#"
+#[derive(Debug, Parser)] // Some comment comment with #[derive(Parser, Debug)].
 #[command(about = "description", long_about = None)]
 struct Data {}
         "#


### PR DESCRIPTION
This PR fixes parsing `#[derive(...)]` block in text, esp. with comments after that.

Fix #25.