### PR TITLE
ci: improve publishing release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,52 +1,46 @@
-name: Build and Release
-
+name: Release
 on:
   release:
     types: [published]
 
 jobs:
   build:
+    name: Build for ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    strategy:
+    strategy:      
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        architecture: [x86_64] # Since Rust doesn't natively target x86 for modern platforms, we're focusing on x86_64
+        include:
+          - os: ubuntu-20.04
+            name: linux64
+            artifact_name: target/release/keepsorted
+            asset_name: keepsorted-linux64
+          - os: macos-12
+            name: macos
+            artifact_name: target/release/keepsorted
+            asset_name: keepsorted-macos
 
     steps:
-    # Step 1: Check out the repository
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-    # Step 2: Install Rust
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      - name: Build
+        run: cargo build --release --all-targets
 
-    # Step 3: Build the project
-    - name: Build the project
-      run: cargo build --release --all-targets
+      - name: Prepare Release Binary
+        run: |
+          mkdir -p release
+          cp target/release/keepsorted release/keepsorted-${{ matrix.asset_name }}
 
-    # Step 4: Create a release binary file name
-    - name: Prepare release binary
-      run: |
-        mkdir -p release
-        cp target/release/keepsorted release/keepsorted-${{ matrix.os }}-${{ matrix.architecture }}
+      - name: Compress Release Binary
+        run: |
+          tar -czvf keepsorted-${{ matrix.asset_name }}.tar.gz -C release keepsorted-${{ matrix.asset_name }}
 
-    # Step 5: Compress the binary using tar.gz
-    - name: Tar the binary
-      run: |
-        tar -czvf keepsorted-${{ matrix.os }}-${{ matrix.architecture }}.tar.gz -C release keepsorted-${{ matrix.os }}-${{ matrix.architecture }}
-
-    # Step 6: Upload the tar.gz to the GitHub release
-    - name: Upload Release Assets
-      uses: actions/upload-release-asset@v1.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./keepsorted-${{ matrix.os }}-${{ matrix.architecture }}.tar.gz
-        asset_name: keepsorted-${{ matrix.os }}-${{ matrix.architecture }}.tar.gz
-        asset_content_type: application/gzip
+      - name: Upload Release Assets
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./keepsorted-${{ matrix.asset_name }}.tar.gz
+          asset_name: keepsorted-${{ matrix.asset_name }}.tar.gz
+          asset_content_type: application/gzip
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,18 +5,15 @@ on:
 
 jobs:
   build:
-    name: Build for ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    strategy:      
+    strategy:
       matrix:
         include:
           - os: ubuntu-20.04
             name: linux64
-            artifact_name: target/release/keepsorted
             asset_name: keepsorted-linux64
           - os: macos-12
             name: macos
-            artifact_name: target/release/keepsorted
             asset_name: keepsorted-macos
 
     steps:
@@ -28,19 +25,13 @@ jobs:
       - name: Prepare Release Binary
         run: |
           mkdir -p release
-          cp target/release/keepsorted release/keepsorted-${{ matrix.asset_name }}
-
-      - name: Compress Release Binary
-        run: |
+          cp target/release/keepsorted release/${{ matrix.asset_name }}
           tar -czvf keepsorted-${{ matrix.asset_name }}.tar.gz -C release keepsorted-${{ matrix.asset_name }}
 
-      - name: Upload Release Assets
+      - name: Upload Release Asset
         uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./keepsorted-${{ matrix.asset_name }}.tar.gz
           asset_name: keepsorted-${{ matrix.asset_name }}.tar.gz
           asset_content_type: application/gzip
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
           cp target/release/keepsorted release/${{ matrix.asset_name }}
           tar -czvf keepsorted-${{ matrix.asset_name }}.tar.gz -C release keepsorted-${{ matrix.asset_name }}
 
-      - name: Upload Release Asset
+      - name: Upload Compressed Release Asset (tar.gz)
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,3 +37,13 @@ jobs:
           asset_path: ./keepsorted-${{ matrix.asset_name }}.tar.gz
           asset_name: keepsorted-${{ matrix.asset_name }}.tar.gz
           asset_content_type: application/gzip
+
+      - name: Upload Original Binary
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./release/${{ matrix.asset_name }}
+          asset_name: keepsorted-${{ matrix.asset_name }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./keepsorted-${{ matrix.asset_name }}.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+- (add updates here)
+
+## [0.1.1] - 2024-10-01
+
 ### Added
 
-- Keep Rust derive tokens together, eg. `Serialize` and `serde::Serialize`
+- (Experimental) Keep Rust derive tokens together, eg. `Serialize` and `serde::Serialize`
 
 ## [0.1.0] - 2024-09-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keepsorted"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A tool for sorting blocks of lines in code files"
 authors = ["Maksym Arutyunyan"]


### PR DESCRIPTION
This PR prepares the next release and enhances the CI release workflow.

- Bumped the version for the upcoming release
- Updated the changelog with the latest changes
- Improved the CI release process:
  - Published release assets with generic Linux and macOS names
  - Included both the original binary and the compressed `.tar.gz` versions for each platform
