### PR TITLE
Grouped traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["sorting", "code", "command-line"]
 
 [features]
+default = ["config"]
 config = ["dep:toml", "dep:serde"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ config = ["dep:toml", "dep:serde"]
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
+itertools = "0.14.0"
 once_cell = "1.19.0"
 regex = "1"
 serde = { version = "1.0.219", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,15 @@ repository = "https://github.com/maksym-arutyunyan/keepsorted"
 readme = "README.md"
 keywords = ["sorting", "code", "command-line"]
 
+[features]
+config = ["dep:toml", "dep:serde"]
+
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 once_cell = "1.19.0"
 regex = "1"
+serde = { version = "1.0.219", features = ["derive"], optional = true }
+toml = { version = "0.8.23", optional = true }
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,13 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub mod strategies;
 
 #[cfg(feature = "config")]
 #[derive(Debug, Default, serde::Deserialize)]
 pub struct Config {
-    #[serde(skip)]
-    pub(crate) path: PathBuf,
     pub(crate) groups: HashMap<String, Vec<String>>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,29 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub mod strategies;
+
+#[cfg(feature = "config")]
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct Config {
+    #[serde(skip)]
+    pub(crate) path: PathBuf,
+    pub(crate) groups: HashMap<String, Vec<String>>,
+}
 
 static RE_KEEP_SORTED: Lazy<Regex> = Lazy::new(re_keyword_keep_sorted);
 static RE_IGNORE_FILE: Lazy<Regex> = Lazy::new(re_keyword_ignore_file);
 static RE_IGNORE_BLOCK: Lazy<Regex> = Lazy::new(re_keyword_ignore_block);
 
-pub fn process_file(path: &Path, features: Vec<String>) -> io::Result<()> {
+pub fn process_file(
+    path: &Path,
+    features: Vec<String>,
+    #[cfg(feature = "config")] config: Config,
+) -> io::Result<()> {
     let mut content = fs::read_to_string(path)?;
     let ends_with_newline = content.ends_with('\n');
     if !ends_with_newline {
@@ -19,7 +32,12 @@ pub fn process_file(path: &Path, features: Vec<String>) -> io::Result<()> {
     }
 
     let lines: Vec<_> = content.split_inclusive('\n').map(String::from).collect();
-    let output_lines = process_lines(classify(path, features), lines)?;
+    let output_lines = process_lines(
+        classify(path, features),
+        lines,
+        #[cfg(feature = "config")]
+        config,
+    )?;
 
     let mut writer = BufWriter::new(File::create(path)?);
     for (i, line) in output_lines.iter().enumerate() {
@@ -48,7 +66,11 @@ pub enum Strategy {
     RustDeriveCanonical,
 }
 
-pub fn process_lines(strategy: Strategy, lines: Vec<String>) -> io::Result<Vec<String>> {
+pub fn process_lines(
+    strategy: Strategy,
+    lines: Vec<String>,
+    #[cfg(feature = "config")] config: Config,
+) -> io::Result<Vec<String>> {
     if is_ignore_file(&lines) {
         return Ok(lines);
     }
@@ -57,10 +79,14 @@ pub fn process_lines(strategy: Strategy, lines: Vec<String>) -> io::Result<Vec<S
         Strategy::Bazel => crate::strategies::bazel::process(lines),
         Strategy::CargoToml => crate::strategies::cargo_toml::process(lines),
         Strategy::Gitignore => crate::strategies::gitignore::process(lines),
-        Strategy::RustDeriveAlphabetical => {
-            crate::strategies::rust_derive::process(lines, strategy)
+        Strategy::RustDeriveAlphabetical | Strategy::RustDeriveCanonical => {
+            crate::strategies::rust_derive::process(
+                lines,
+                strategy,
+                #[cfg(feature = "config")]
+                config,
+            )
         }
-        Strategy::RustDeriveCanonical => crate::strategies::rust_derive::process(lines, strategy),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,20 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
+use crate::strategies::rust_derive::RustDeriveStrategy;
+
 pub mod strategies;
+
+pub type TraitGroups = std::collections::HashMap<String, Vec<String>>;
 
 #[cfg(feature = "config")]
 #[derive(Debug, Default, serde::Deserialize)]
 pub struct Config {
-    pub(crate) groups: HashMap<String, Vec<String>>,
+    #[serde(default)]
+    pub groups: TraitGroups,
 }
 
 static RE_KEEP_SORTED: Lazy<Regex> = Lazy::new(re_keyword_keep_sorted);
@@ -20,7 +24,7 @@ static RE_IGNORE_BLOCK: Lazy<Regex> = Lazy::new(re_keyword_ignore_block);
 pub fn process_file(
     path: &Path,
     features: Vec<String>,
-    #[cfg(feature = "config")] config: Config,
+    groups: Option<&TraitGroups>,
 ) -> io::Result<()> {
     let mut content = fs::read_to_string(path)?;
     let ends_with_newline = content.ends_with('\n');
@@ -30,12 +34,7 @@ pub fn process_file(
     }
 
     let lines: Vec<_> = content.split_inclusive('\n').map(String::from).collect();
-    let output_lines = process_lines(
-        classify(path, features),
-        lines,
-        #[cfg(feature = "config")]
-        config,
-    )?;
+    let output_lines = process_lines(classify(path, features), lines, groups)?;
 
     let mut writer = BufWriter::new(File::create(path)?);
     for (i, line) in output_lines.iter().enumerate() {
@@ -67,7 +66,7 @@ pub enum Strategy {
 pub fn process_lines(
     strategy: Strategy,
     lines: Vec<String>,
-    #[cfg(feature = "config")] config: Config,
+    groups: Option<&TraitGroups>,
 ) -> io::Result<Vec<String>> {
     if is_ignore_file(&lines) {
         return Ok(lines);
@@ -77,13 +76,12 @@ pub fn process_lines(
         Strategy::Bazel => crate::strategies::bazel::process(lines),
         Strategy::CargoToml => crate::strategies::cargo_toml::process(lines),
         Strategy::Gitignore => crate::strategies::gitignore::process(lines),
-        Strategy::RustDeriveAlphabetical | Strategy::RustDeriveCanonical => {
-            crate::strategies::rust_derive::process(
-                lines,
-                strategy,
-                #[cfg(feature = "config")]
-                config,
-            )
+        Strategy::RustDeriveAlphabetical => {
+            crate::strategies::rust_derive::process(lines, RustDeriveStrategy::Alphabetical, groups)
+        }
+
+        Strategy::RustDeriveCanonical => {
+            crate::strategies::rust_derive::process(lines, RustDeriveStrategy::Canonical, groups)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,15 @@ struct Args {
         help = "Experimental feature flags. Provide a list of features to enable."
     )]
     features: Option<Vec<String>>,
+
+    #[cfg(feature = "config")]
+    #[arg(
+        short = 'c',
+        long,
+        value_name = "CONFIG",
+        help = "Path to a toml file containg rust-derive groups"
+    )]
+    config: Option<String>,
 }
 
 fn main() -> io::Result<()> {
@@ -64,9 +73,29 @@ fn main() -> io::Result<()> {
         std::process::exit(1);
     }
 
+    #[cfg(feature = "config")]
+    let config = {
+        use keepsorted::Config;
+        use std::path::PathBuf;
+        use toml::from_str;
+        // Get the configuration file path from the args or the environment
+        let config_path: Option<String> = args.config.or(std::env::var("KEEPSORTED_CONFIG").ok());
+        // Create the configuration
+        config_path
+            .and_then(|path| std::fs::read_to_string(path).ok())
+            .and_then(|text| toml::from_str::<Config>(&text).ok())
+            .unwrap_or_default()
+    };
+
     // Check for experimental features
     let features = args.features.unwrap_or_default();
-    process_file(path, features).map_err(|e| {
+    process_file(
+        path,
+        features,
+        #[cfg(feature = "config")]
+        config,
+    )
+    .map_err(|e| {
         eprintln!(
             "{}: failed to process file {}: {}",
             env!("CARGO_PKG_NAME"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,8 +76,6 @@ fn main() -> io::Result<()> {
     #[cfg(feature = "config")]
     let config = {
         use keepsorted::Config;
-        use std::path::PathBuf;
-        use toml::from_str;
         // Get the configuration file path from the args or the environment
         let config_path: Option<String> = args.config.or(std::env::var("KEEPSORTED_CONFIG").ok());
         // Create the configuration
@@ -89,13 +87,12 @@ fn main() -> io::Result<()> {
 
     // Check for experimental features
     let features = args.features.unwrap_or_default();
-    process_file(
-        path,
-        features,
-        #[cfg(feature = "config")]
-        config,
-    )
-    .map_err(|e| {
+    #[cfg(not(feature = "config"))]
+    let result = process_file(path, features, None);
+    #[cfg(feature = "config")]
+    let result = process_file(path, features, Some(&config.groups));
+
+    result.map_err(|e| {
         eprintln!(
             "{}: failed to process file {}: {}",
             env!("CARGO_PKG_NAME"),

--- a/src/strategies/rust_derive.rs
+++ b/src/strategies/rust_derive.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "config")]
+use crate::Config;
 use crate::Strategy;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -12,7 +14,11 @@ static RE_DERIVE_END: Lazy<Regex> = Lazy::new(re_derive_end);
 const STAY_ONE_LINE_LEN: usize = 97;
 const BREAK_INTO_MANY_LINES_LEN: usize = 101;
 
-pub(crate) fn process(lines: Vec<String>, strategy: Strategy) -> io::Result<Vec<String>> {
+pub(crate) fn process(
+    lines: Vec<String>,
+    strategy: Strategy,
+    #[cfg(feature = "config")] config: Config,
+) -> io::Result<Vec<String>> {
     let mut output_lines: Vec<String> = Vec::new();
     let mut block = Vec::new();
     let mut is_sorting_block = false;

--- a/src/strategies/rust_derive.rs
+++ b/src/strategies/rust_derive.rs
@@ -1,6 +1,5 @@
-#[cfg(feature = "config")]
-use crate::Config;
-use crate::Strategy;
+use crate::TraitGroups;
+use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::{collections::HashMap, io};
@@ -26,17 +25,27 @@ const CANONICAL_TRAITS: &[&str] = &[
     "Display",
     "Default",
 ];
-const GROUP_PRIORITY_OFFSET: usize = CANONICAL_TRAITS.len();
+
+#[derive(Copy, Clone)]
+pub enum RustDeriveStrategy {
+    Alphabetical,
+    Canonical,
+}
 
 pub(crate) fn process(
     lines: Vec<String>,
-    strategy: Strategy,
-    #[cfg(feature = "config")] config: Config,
+    strategy: RustDeriveStrategy,
+    groups: Option<&TraitGroups>,
 ) -> io::Result<Vec<String>> {
     let mut output_lines: Vec<String> = Vec::new();
     let mut block = Vec::new();
     let mut is_sorting_block = false;
     let mut is_ignore_block_prev_line = false;
+
+    let priority_index = match strategy {
+        RustDeriveStrategy::Alphabetical => build_priority_index(&[], groups),
+        RustDeriveStrategy::Canonical => build_priority_index(CANONICAL_TRAITS, groups),
+    };
 
     for line in lines {
         let mut is_derive_begin = false;
@@ -53,13 +62,7 @@ pub(crate) fn process(
             if !is_derive_begin {
                 block.push(line.clone());
             }
-            block = sort(
-                block,
-                is_ignore_block_prev_line,
-                strategy,
-                #[cfg(feature = "config")]
-                &config,
-            );
+            block = sort(block, is_ignore_block_prev_line, &priority_index);
             is_ignore_block_prev_line = false;
             is_sorting_block = false;
             output_lines.append(&mut block);
@@ -73,13 +76,7 @@ pub(crate) fn process(
     }
 
     if is_sorting_block {
-        block = sort(
-            block,
-            is_ignore_block_prev_line,
-            strategy,
-            #[cfg(feature = "config")]
-            &config,
-        );
+        block = sort(block, is_ignore_block_prev_line, &priority_index);
         output_lines.append(&mut block);
     }
 
@@ -89,8 +86,7 @@ pub(crate) fn process(
 fn sort(
     block: Vec<String>,
     is_ignore_block_prev_line: bool,
-    strategy: Strategy,
-    #[cfg(feature = "config")] config: &Config,
+    priority_index: &HashMap<&str, usize>,
 ) -> Vec<String> {
     if is_ignore_block_prev_line || is_ignore_block(&block) {
         return block;
@@ -114,11 +110,7 @@ fn sort(
             .filter(|t| !t.is_empty())
             .collect();
 
-        match strategy {
-            Strategy::RustDeriveAlphabetical => traits = aphabetical_sort(config, traits),
-            Strategy::RustDeriveCanonical => traits = canonical_sort(config, traits),
-            _ => return block,
-        }
+        traits = priority_sort(traits, priority_index);
 
         let sorted_traits = traits.join(", ");
         let new_derive = format!("#[derive({})]", sorted_traits);
@@ -155,7 +147,7 @@ fn extract_last_token(s: &str) -> &str {
     s.split("::").last().unwrap_or(s)
 }
 
-fn priority_sort<'a>(traits: Vec<&'a str>, priority_index: HashMap<&str, usize>) -> Vec<&'a str> {
+fn priority_sort<'a>(traits: Vec<&'a str>, priority_index: &HashMap<&str, usize>) -> Vec<&'a str> {
     // Sort traits by priority index, and by trait name if indices are the same
     let mut sorted_traits = traits;
     sorted_traits.sort_by(|a, b| {
@@ -168,35 +160,31 @@ fn priority_sort<'a>(traits: Vec<&'a str>, priority_index: HashMap<&str, usize>)
 }
 
 fn build_priority_index<'a>(
-    config: &'a Config,
     priority_traits: &[&'a str],
+    groups: Option<&'a TraitGroups>,
 ) -> HashMap<&'a str, usize> {
-    let grouped_traits: Vec<&'a str> = {
-        let mut keys: Vec<_> = config.groups.keys().collect();
-        keys.sort();
-        keys.into_iter()
-            .flat_map(|key| config.groups.get(key).unwrap())
-            .map(|s| String::as_str(s))
+    if let Some(groups) = groups {
+        let grouped_traits: Vec<&'a str> = groups
+            .keys()
+            .sorted()
+            .flat_map(|key| groups.get(key).unwrap().iter().sorted())
+            .map(String::as_str)
+            .collect();
+        priority_traits
+            .iter()
+            .copied()
+            .chain(grouped_traits)
+            .enumerate()
+            .map(|(i, trait_name)| (trait_name, i))
             .collect()
-    };
-
-    priority_traits
-        .iter()
-        .copied()
-        .chain(grouped_traits.into_iter())
-        .enumerate()
-        .map(|(i, trait_name)| (trait_name, i))
-        .collect()
-}
-
-fn aphabetical_sort<'a>(config: &'a Config, traits: Vec<&'a str>) -> Vec<&'a str> {
-    let index = build_priority_index(config, &[]);
-    priority_sort(traits, index)
-}
-
-fn canonical_sort<'a>(config: &'a Config, traits: Vec<&'a str>) -> Vec<&'a str> {
-    let index = build_priority_index(config, CANONICAL_TRAITS);
-    priority_sort(traits, index)
+    } else {
+        priority_traits
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(i, trait_name)| (trait_name, i))
+            .collect()
+    }
 }
 
 fn re_derive_begin() -> Regex {

--- a/src/strategies/rust_derive.rs
+++ b/src/strategies/rust_derive.rs
@@ -3,7 +3,7 @@ use crate::Config;
 use crate::Strategy;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::io;
+use std::{collections::HashMap, io};
 
 use crate::is_ignore_block;
 
@@ -13,6 +13,20 @@ static RE_DERIVE_END: Lazy<Regex> = Lazy::new(re_derive_end);
 // These values count the number of characters and an extra '\n'.
 const STAY_ONE_LINE_LEN: usize = 97;
 const BREAK_INTO_MANY_LINES_LEN: usize = 101;
+
+const CANONICAL_TRAITS: &[&str] = &[
+    "Copy",
+    "Clone",
+    "Eq",
+    "PartialEq",
+    "Ord",
+    "PartialOrd",
+    "Hash",
+    "Debug",
+    "Display",
+    "Default",
+];
+const GROUP_PRIORITY_OFFSET: usize = CANONICAL_TRAITS.len();
 
 pub(crate) fn process(
     lines: Vec<String>,
@@ -39,7 +53,13 @@ pub(crate) fn process(
             if !is_derive_begin {
                 block.push(line.clone());
             }
-            block = sort(block, is_ignore_block_prev_line, strategy);
+            block = sort(
+                block,
+                is_ignore_block_prev_line,
+                strategy,
+                #[cfg(feature = "config")]
+                &config,
+            );
             is_ignore_block_prev_line = false;
             is_sorting_block = false;
             output_lines.append(&mut block);
@@ -53,14 +73,25 @@ pub(crate) fn process(
     }
 
     if is_sorting_block {
-        block = sort(block, is_ignore_block_prev_line, strategy);
+        block = sort(
+            block,
+            is_ignore_block_prev_line,
+            strategy,
+            #[cfg(feature = "config")]
+            &config,
+        );
         output_lines.append(&mut block);
     }
 
     Ok(output_lines)
 }
 
-fn sort(block: Vec<String>, is_ignore_block_prev_line: bool, strategy: Strategy) -> Vec<String> {
+fn sort(
+    block: Vec<String>,
+    is_ignore_block_prev_line: bool,
+    strategy: Strategy,
+    #[cfg(feature = "config")] config: &Config,
+) -> Vec<String> {
     if is_ignore_block_prev_line || is_ignore_block(&block) {
         return block;
     }
@@ -84,8 +115,8 @@ fn sort(block: Vec<String>, is_ignore_block_prev_line: bool, strategy: Strategy)
             .collect();
 
         match strategy {
-            Strategy::RustDeriveAlphabetical => traits = aphabetical_sort(traits),
-            Strategy::RustDeriveCanonical => traits = canonical_sort(traits),
+            Strategy::RustDeriveAlphabetical => traits = aphabetical_sort(config, traits),
+            Strategy::RustDeriveCanonical => traits = canonical_sort(config, traits),
             _ => return block,
         }
 
@@ -124,14 +155,7 @@ fn extract_last_token(s: &str) -> &str {
     s.split("::").last().unwrap_or(s)
 }
 
-fn priority_sort<'a>(traits: Vec<&'a str>, priority_traits: &[&'a str]) -> Vec<&'a str> {
-    // Create a mapping from trait to its priority index
-    let priority_index: std::collections::HashMap<_, _> = priority_traits
-        .iter()
-        .enumerate()
-        .map(|(i, &trait_name)| (trait_name, i))
-        .collect();
-
+fn priority_sort<'a>(traits: Vec<&'a str>, priority_index: HashMap<&str, usize>) -> Vec<&'a str> {
     // Sort traits by priority index, and by trait name if indices are the same
     let mut sorted_traits = traits;
     sorted_traits.sort_by(|a, b| {
@@ -143,27 +167,36 @@ fn priority_sort<'a>(traits: Vec<&'a str>, priority_traits: &[&'a str]) -> Vec<&
     sorted_traits
 }
 
-fn aphabetical_sort(traits: Vec<&str>) -> Vec<&str> {
-    priority_sort(traits, &[])
+fn build_priority_index<'a>(
+    config: &'a Config,
+    priority_traits: &[&'a str],
+) -> HashMap<&'a str, usize> {
+    let grouped_traits: Vec<&'a str> = {
+        let mut keys: Vec<_> = config.groups.keys().collect();
+        keys.sort();
+        keys.into_iter()
+            .flat_map(|key| config.groups.get(key).unwrap())
+            .map(|s| String::as_str(s))
+            .collect()
+    };
+
+    priority_traits
+        .iter()
+        .copied()
+        .chain(grouped_traits.into_iter())
+        .enumerate()
+        .map(|(i, trait_name)| (trait_name, i))
+        .collect()
 }
 
-fn canonical_sort(traits: Vec<&str>) -> Vec<&str> {
-    priority_sort(
-        traits,
-        // Define the canonical order of traits
-        &[
-            "Copy",
-            "Clone",
-            "Eq",
-            "PartialEq",
-            "Ord",
-            "PartialOrd",
-            "Hash",
-            "Debug",
-            "Display",
-            "Default",
-        ],
-    )
+fn aphabetical_sort<'a>(config: &'a Config, traits: Vec<&'a str>) -> Vec<&'a str> {
+    let index = build_priority_index(config, &[]);
+    priority_sort(traits, index)
+}
+
+fn canonical_sort<'a>(config: &'a Config, traits: Vec<&'a str>) -> Vec<&'a str> {
+    let index = build_priority_index(config, CANONICAL_TRAITS);
+    priority_sort(traits, index)
 }
 
 fn re_derive_begin() -> Regex {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,9 +2,13 @@ use keepsorted::{process_lines, Strategy, TraitGroups};
 use std::io::{self};
 
 // Helper function to hide text-lines conversion.
-pub fn process_input(strategy: Strategy, text: &str, groups: &TraitGroups) -> io::Result<String> {
+pub fn process_input(
+    strategy: Strategy,
+    text: &str,
+    groups: Option<&TraitGroups>,
+) -> io::Result<String> {
     let lines: Vec<_> = text.lines().map(|line| format!("{}\n", line)).collect();
-    let mut processed_lines = process_lines(strategy, lines, Some(groups))?;
+    let mut processed_lines = process_lines(strategy, lines, groups)?;
     if let Some(last) = processed_lines.last_mut() {
         last.truncate(last.trim_end_matches('\n').len());
     }
@@ -17,9 +21,8 @@ macro_rules! test_inner {
     ($strategy:expr, $input:expr, $expected:expr) => {{
         let strategy = $strategy;
         let input = $input;
-        let groups = Default::default();
         let expected = $expected;
-        let result = common::process_input(strategy, input, &groups).unwrap();
+        let result = common::process_input(strategy, input, None).unwrap();
         assert!(
             result == expected,
             "Expected: {}\nActual: {}",
@@ -32,7 +35,7 @@ macro_rules! test_inner {
         let input = $input;
         let groups = $groups;
         let expected = $expected;
-        let result = common::process_input(strategy, input, groups).unwrap();
+        let result = common::process_input(strategy, input, Some(&groups)).unwrap();
         assert!(
             result == expected,
             "Expected: {}\nActual: {}",

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -4,7 +4,12 @@ use std::io::{self};
 // Helper function to hide text-lines conversion.
 pub fn process_input(strategy: Strategy, text: &str) -> io::Result<String> {
     let lines: Vec<_> = text.lines().map(|line| format!("{}\n", line)).collect();
-    let mut processed_lines = process_lines(strategy, lines)?;
+    let mut processed_lines = process_lines(
+        strategy,
+        lines,
+        #[cfg(feature = "config")]
+        Default::default(),
+    )?;
     if let Some(last) = processed_lines.last_mut() {
         last.truncate(last.trim_end_matches('\n').len());
     }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,15 +1,10 @@
-use keepsorted::{process_lines, Strategy};
+use keepsorted::{process_lines, Strategy, TraitGroups};
 use std::io::{self};
 
 // Helper function to hide text-lines conversion.
-pub fn process_input(strategy: Strategy, text: &str) -> io::Result<String> {
+pub fn process_input(strategy: Strategy, text: &str, groups: &TraitGroups) -> io::Result<String> {
     let lines: Vec<_> = text.lines().map(|line| format!("{}\n", line)).collect();
-    let mut processed_lines = process_lines(
-        strategy,
-        lines,
-        #[cfg(feature = "config")]
-        Default::default(),
-    )?;
+    let mut processed_lines = process_lines(strategy, lines, Some(groups))?;
     if let Some(last) = processed_lines.last_mut() {
         last.truncate(last.trim_end_matches('\n').len());
     }
@@ -22,8 +17,22 @@ macro_rules! test_inner {
     ($strategy:expr, $input:expr, $expected:expr) => {{
         let strategy = $strategy;
         let input = $input;
+        let groups = Default::default();
         let expected = $expected;
-        let result = common::process_input(strategy, input).unwrap();
+        let result = common::process_input(strategy, input, &groups).unwrap();
+        assert!(
+            result == expected,
+            "Expected: {}\nActual: {}",
+            expected,
+            result
+        );
+    }};
+    ($strategy:expr, $input:expr, $expected:expr, $groups:expr) => {{
+        let strategy = $strategy;
+        let input = $input;
+        let groups = $groups;
+        let expected = $expected;
+        let result = common::process_input(strategy, input, groups).unwrap();
         assert!(
             result == expected,
             "Expected: {}\nActual: {}",

--- a/tests/rust_derive_grouped.rs
+++ b/tests/rust_derive_grouped.rs
@@ -1,0 +1,320 @@
+#[macro_use]
+mod common;
+
+use keepsorted::{
+    Strategy::{RustDeriveAlphabetical, RustDeriveCanonical},
+    TraitGroups,
+};
+use once_cell::sync::Lazy;
+
+static GROUPS: Lazy<TraitGroups> = Lazy::new(|| {
+    [
+        ("bevy", &["Component", "Resource"]),
+        ("serde", &["Deserialize", "Serialize"]),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v.iter().map(|s| s.to_string()).collect()))
+    .collect()
+});
+
+#[test]
+fn rust_derive_alphabetical() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+#[derive(serde::Serialize, C, B, A, Ord, Copy, c, b, a, Serialize)]
+struct Data {}
+        "#,
+        r#"
+#[derive(Serialize, A, B, C, Copy, Ord, serde::Serialize, a, b, c)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+#[test]
+fn rust_derive_canonical() {
+    test_inner!(
+        RustDeriveCanonical,
+        r#"
+#[derive(serde::Serialize, C, B, A, Ord, Copy, c, b, a, Serialize)]
+struct Data {}
+        "#,
+        r#"
+#[derive(Copy, Ord, Serialize, A, B, C, serde::Serialize, a, b, c)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+#[test]
+fn rust_derive_alphabetical_indented() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+mod foo {
+    #[derive(C, B, A, Ord, Copy)]
+    struct Data {}
+}
+        "#,
+        r#"
+mod foo {
+    #[derive(A, B, C, Copy, Ord)]
+    struct Data {}
+}
+        "#,
+        &GROUPS
+    );
+}
+
+#[test]
+fn rust_derive_canonical_indented() {
+    test_inner!(
+        RustDeriveCanonical,
+        r#"
+mod foo {
+    #[derive(C, B, A, Ord, Copy)]
+    struct Data {}
+}
+        "#,
+        r#"
+mod foo {
+    #[derive(Copy, Ord, A, B, C)]
+    struct Data {}
+}
+        "#,
+        &GROUPS
+    );
+}
+
+//       1         2         3         4         5         6         7         8         9
+//3456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456
+#[test]
+fn rust_derive_long_stays_one_line() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        //         2         3         4         5         6         7         8         9
+        //12345678901234567890123456789012345678901234567890123456789012345678901234567890123456
+        r#"
+#[derive(A01, A02, A03, A04, A05, A06, A07, A08, A09, A10, A11, A12, A13, A14, A15, A16, A17xx)]
+struct Data {}
+        "#,
+        r#"
+#[derive(A01, A02, A03, A04, A05, A06, A07, A08, A09, A10, A11, A12, A13, A14, A15, A16, A17xx)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+//       1         2         3         4         5         6         7         8         9
+//34567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567
+#[test]
+fn rust_derive_long_breaks_into_three_lines() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        //         2         3         4         5         6         7         8         9
+        //123456789012345678901234567890123456789012345678901234567890123456789012345678901234567
+        r#"
+#[derive(A01, A02, A03, A04, A05, A06, A07, A08, A09, A10, A11, A12, A13, A14, A15, A16, A17xxx)]
+struct Data {}
+        "#,
+        r#"
+#[derive(
+    A01, A02, A03, A04, A05, A06, A07, A08, A09, A10, A11, A12, A13, A14, A15, A16, A17xxx,
+)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+//       1         2         3         4         5         6         7         8         9         0
+//345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901
+#[test]
+fn rust_derive_long_stays_three_lines() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        //         2         3         4         5         6         7         8         9         0
+        //1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901
+        r#"
+#[derive(
+    A01, A02, A03, A04, A05, A06, A07, A08, A09, A10, A11, A12, A13, A14, A15, A16, A17xx, B01, B02x,
+)]
+struct Data {}
+        "#,
+        r#"
+#[derive(
+    A01, A02, A03, A04, A05, A06, A07, A08, A09, A10, A11, A12, A13, A14, A15, A16, A17xx, B01, B02x,
+)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+//       1         2         3         4         5         6         7         8         9         0
+//3456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+#[test]
+fn rust_derive_long_breaks_into_many_lines() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        //         2         3         4         5         6         7         8         9         0
+        //12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+        r#"
+#[derive(
+    A01, A02, A03, A04, A05, A06, A07, A08, A09, A10, A11, A12, A13, A14, A15, A16, A17xx, B01, B02xx,
+)]
+struct Data {}
+        "#,
+        r#"
+#[derive(
+    A01,
+    A02,
+    A03,
+    A04,
+    A05,
+    A06,
+    A07,
+    A08,
+    A09,
+    A10,
+    A11,
+    A12,
+    A13,
+    A14,
+    A15,
+    A16,
+    A17xx,
+    B01,
+    B02xx,
+)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+#[test]
+fn rust_derive_one_line_ignored() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+// keepsorted: ignore block
+#[derive(C, B, A, Ord, Copy)]
+struct Data {}
+        "#,
+        r#"
+// keepsorted: ignore block
+#[derive(C, B, A, Ord, Copy)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+#[test]
+fn rust_derive_three_lines_ignored() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+// keepsorted: ignore block
+#[derive(
+    C, B, A, Ord, Copy,
+)]
+struct Data {}
+        "#,
+        r#"
+// keepsorted: ignore block
+#[derive(
+    C, B, A, Ord, Copy,
+)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+#[test]
+fn rust_derive_many_lines_ignored() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+// keepsorted: ignore block
+#[derive(
+    C,
+    B,
+    A,
+    Ord,
+    Copy,
+)]
+struct Data {}
+        "#,
+        r#"
+// keepsorted: ignore block
+#[derive(
+    C,
+    B,
+    A,
+    Ord,
+    Copy,
+)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+#[test]
+fn rust_derive_issue_25_1() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+#[derive(Parser, Debug)] // Some comment.
+struct Data {}
+        "#,
+        r#"
+#[derive(Debug, Parser)] // Some comment.
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+#[test]
+fn rust_derive_issue_25_2() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+#[derive(Parser, Debug)] // Some comment.
+#[command(about = "description", long_about = None)]
+struct Data {}
+        "#,
+        r#"
+#[derive(Debug, Parser)] // Some comment.
+#[command(about = "description", long_about = None)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}
+
+#[test]
+fn rust_derive_issue_25_3() {
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+#[derive(Parser, Debug)] // Some comment comment with #[derive(Parser, Debug)].
+#[command(about = "description", long_about = None)]
+struct Data {}
+        "#,
+        r#"
+#[derive(Debug, Parser)] // Some comment comment with #[derive(Parser, Debug)].
+#[command(about = "description", long_about = None)]
+struct Data {}
+        "#,
+        &GROUPS
+    );
+}


### PR DESCRIPTION
Here it is. It works mostly as I described in #33. Any and all feedback is appreciated. I also understand if you do not want to merge (and in the future have to maintain) this.

I tried to keep the implementation as close to the the original as reasonable. It ends up appending the sorted members of each group (which are in turn sorted by name) to the traits that are used for the priority map.
Further I put the serde and toml dependencies behind the feature `config` so they are opt-in.

I'm using it succesfully on my projects, but I didn't add any tests specifically for this yet.

It can be used like `keepsorted -f rust_derive_canonical -c keepsorted.toml src/main.rs` or by setting an env var `KEEPSORTED_CONFIG=keepsorted.toml keepsorted -f rust_derive_canonical src/main.rs`.

A config file can look like this:
```toml
[groups]
a = ["trait1", "trait2"]
```
No fancy checking is performed:
- invalid toml will be ignored
- having duplicate traits will possibly return inconsistent order
- exact matches only

Cheers