### PR TITLE
feat: add Lua support

### DIFF
--- a/.github/workflows/ci-pr-only-cov.yaml
+++ b/.github/workflows/ci-pr-only-cov.yaml
@@ -1,11 +1,12 @@
-# Copied & adapted (job name, version label) from
-# https://github.com/ytanikin/PRConventionalCommits?tab=readme-ov-file#usage-with-labeling-where-label-is-just-a-task-type
-
 name: PR Conventional Commit Validation
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   validate-pr-title:
@@ -13,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses:  ytanikin/PRConventionalCommits@1.3.0
+        uses: ytanikin/PRConventionalCommits@1.3.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'

--- a/.github/workflows/ci-pr-only-cov.yaml
+++ b/.github/workflows/ci-pr-only-cov.yaml
@@ -1,5 +1,6 @@
 # Copied & adapted (job name, version label) from
 # https://github.com/ytanikin/PRConventionalCommits?tab=readme-ov-file#usage-with-labeling-where-label-is-just-a-task-type
+
 name: PR Conventional Commit Validation
 
 on:

--- a/.github/workflows/ci-pr-only-cov.yaml
+++ b/.github/workflows/ci-pr-only-cov.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses:  ytanikin/PRConventionalCommits@8d258b54939f6769fcd935a52b96d6b0383a00c5 # v1.2.0
+        uses:  ytanikin/PRConventionalCommits@1.3.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'

--- a/.github/workflows/ci-pr-only-cov.yaml
+++ b/.github/workflows/ci-pr-only-cov.yaml
@@ -6,16 +6,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   validate-pr-title:
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses: ytanikin/PRConventionalCommits@1.3.0
+        uses: ytanikin/PRConventionalCommits@8d258b54939f6769fcd935a52b96d6b0383a00c5 # v1.2.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'

--- a/.github/workflows/ci-pr-only-cov.yaml
+++ b/.github/workflows/ci-pr-only-cov.yaml
@@ -1,3 +1,5 @@
+# Copied & adapted (job name, version label) from
+# https://github.com/ytanikin/PRConventionalCommits?tab=readme-ov-file#usage-with-labeling-where-label-is-just-a-task-type
 name: PR Conventional Commit Validation
 
 on:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub fn process_file(path: &Path, features: Vec<String>) -> io::Result<()> {
     writer.flush()
 }
 
-#[derive(Clone, Copy)]
+#[derive(Copy, Clone)]
 pub enum Strategy {
     Generic,
     Bazel,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ fn is_rust(path: &Path) -> bool {
 }
 
 fn re_keyword_keep_sorted() -> Regex {
-    Regex::new(r"(?i)^\s*(#|\/\/)(\s*keepsorted\s*:)?\s*keep\s+sorted\s*\.?\s*$")
+    Regex::new(r"(?i)^\s*(#|\/\/|--)(\s*keepsorted\s*:)?\s*keep\s+sorted\s*\.?\s*$")
         .expect("Failed to build regex for keep sorted")
 }
 
@@ -138,6 +138,8 @@ fn test_re_keyword_keep_sorted() {
         "  //  Keep sorted   .  ",
         "  //keepsorted: keep sorted",
         "  //   keepsorted  : keep   sorted  .  ",
+        "--keepsorted: keep sorted",
+        "-- keep sorted",
     ] {
         assert!(
             re.is_match(line),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub fn process_file(path: &Path, features: Vec<String>) -> io::Result<()> {
     writer.flush()
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub enum Strategy {
     Generic,
     Bazel,
@@ -124,7 +124,7 @@ fn is_rust(path: &Path) -> bool {
 
 fn re_keyword_keep_sorted() -> Regex {
     Regex::new(
-        r"(?i)^\s*(#|\/\/|#\s+keepsorted\s*:|\/\/\s+keepsorted\s*:)\s*keep\s+sorted\s*\.?\s*$",
+        r"(?i)^\s*(#|\/\/|#\s*keepsorted\s*:|\/\/\s*keepsorted\s*:)\s*keep\s+sorted\s*\.?\s*$",
     )
     .expect("Failed to build regex for keep sorted")
 }
@@ -133,10 +133,12 @@ fn re_keyword_keep_sorted() -> Regex {
 fn test_re_keyword_keep_sorted() {
     let re = re_keyword_keep_sorted();
     for line in [
+        "  #Keep sorted",
         "  # Keep sorted  ",
         "  # Keep   sorted .  ",
         "  #   keepsorted  : keep   sorted  .  ",
         "  //  Keep sorted   .  ",
+        "  //keepsorted: keep sorted",
         "  //   keepsorted  : keep   sorted  .  ",
     ] {
         assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,10 +123,8 @@ fn is_rust(path: &Path) -> bool {
 }
 
 fn re_keyword_keep_sorted() -> Regex {
-    Regex::new(
-        r"(?i)^\s*(#|\/\/|#\s*keepsorted\s*:|\/\/\s*keepsorted\s*:)\s*keep\s+sorted\s*\.?\s*$",
-    )
-    .expect("Failed to build regex for keep sorted")
+    Regex::new(r"(?i)^\s*(#|\/\/)(\s*keepsorted\s*:)?\s*keep\s+sorted\s*\.?\s*$")
+        .expect("Failed to build regex for keep sorted")
 }
 
 #[test]

--- a/src/strategies/generic.rs
+++ b/src/strategies/generic.rs
@@ -15,7 +15,7 @@ pub(crate) fn process(lines: Vec<String>) -> io::Result<Vec<String>> {
             }
             is_sorting_block = true;
             output_lines.push(line);
-        } else if is_sorting_block && line.trim().is_empty() {
+        } else if is_sorting_block && is_block_end(&line) {
             block = sort(block, is_ignore_block_prev_line);
             is_ignore_block_prev_line = false;
             is_sorting_block = false;
@@ -40,6 +40,11 @@ pub(crate) fn process(lines: Vec<String>) -> io::Result<Vec<String>> {
 struct Item {
     comment: Vec<String>,
     code: String,
+}
+
+fn is_block_end(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.is_empty() || trimmed.starts_with([')', ']', '}'])
 }
 
 /// Sorts a block of lines, keeping associated comments with their items.
@@ -76,5 +81,5 @@ fn sort(block: Vec<String>, is_ignore_block_prev_line: bool) -> Vec<String> {
 
 fn is_single_line_comment(line: &str) -> bool {
     let trimmed = line.trim();
-    trimmed.starts_with('#') || trimmed.starts_with("//")
+    trimmed.starts_with('#') || trimmed.starts_with("//") || trimmed.starts_with("--")
 }

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -358,3 +358,28 @@ local config = {
         "#
     );
 }
+
+#[test]
+fn generic_nested_lua_tables_specific_example() {
+    test_inner!(
+        Generic,
+        r#"
+local candidates = {
+  light = {
+    -- keep sorted
+    "catppuccin-latte",
+    "base16-catppuccin-latte",
+  },
+  dark = {},
+}"#,
+        r#"
+local candidates = {
+  light = {
+    -- keep sorted
+    "base16-catppuccin-latte",
+    "catppuccin-latte",
+  },
+  dark = {},
+}"#
+    )
+}

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -304,3 +304,57 @@ y,
         "#
     );
 }
+
+#[test]
+fn generic_simple_lua_table() {
+    test_inner!(
+        Generic,
+        r#"
+local config = {
+    -- Keep sorted.
+    setting = true,
+    name = "some name",
+}
+        "#,
+        r#"
+local config = {
+    -- Keep sorted.
+    name = "some name",
+    setting = true,
+}
+        "#
+    );
+}
+
+#[test]
+fn generic_nested_lua_tables() {
+    test_inner!(
+        Generic,
+        r#"
+local config = {
+    b = {
+        "ghijkl",
+        "abcdef",
+    },
+    a = {
+        -- Keep sorted.
+        "ghijkl",
+        "abcdef",
+    }
+}
+        "#,
+        r#"
+local config = {
+    b = {
+        "ghijkl",
+        "abcdef",
+    },
+    a = {
+        -- Keep sorted.
+        "abcdef",
+        "ghijkl",
+    }
+}
+        "#
+    );
+}


### PR DESCRIPTION
Fixes #40
Implements initial lua support:
- support `--` comment prefix
- slightly smarted end-of-block-detection for the generic strategy
- test-cases for all of the above
- a small improvement of the keyword-regex

Edit: linked issue