### PR TITLE
fix: support Lua-style comment ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `keepsorted` is a command-line tool that helps you sort blocks of lines in your code files.
 
-It works by sorting lines within a block that starts with the activation comment `# Keep sorted` or `// Keep sorted`. 
+It works by sorting lines within a block that starts with the activation comment `# Keep sorted`.
 In some files, like `Cargo.toml`, it sorts automatically without needing an activation comment.
 
 The tool can also recognize comments attached to non-comment lines, like this:
@@ -43,7 +43,7 @@ Comments can begin with `#`, `//`, or `--`. The following examples use `#`.
 
 ### Generic Text Files
 
-For generic text files, the tool sorts blocks that start with `# Keep sorted` or `// Keep sorted` and end with a newline.
+For generic text files, the tool sorts blocks that start with `# Keep sorted` and end with a newline.
 
 ```txt
 # Names
@@ -52,8 +52,8 @@ Alice
 Bob
 Conrad
 
-// Colors
-// Keep sorted
+# Colors
+# Keep sorted
 Blue
 Green
 Red

--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ You can see more examples in the `./tests/e2e-tests/` directory.
 
 ## Keywords
 
-- Use `# Keep sorted`, `// Keep sorted`, or `# keepsorted: keep sorted` to sort the next block of lines
-- Add `# keepsorted: ignore file` anywhere in the file to skip sorting
-- Use `# keepsorted: ignore block` within a block to skip sorting that block
+Comments can begin with `#`, `//`, or `--`. The following examples use `#`.
+
+- `# Keep sorted` or `# keepsorted: keep sorted` sorts the next block of lines
+- `# keepsorted: ignore file` anywhere in the file skips sorting
+- `# keepsorted: ignore block` within a block skips sorting that block
 
 ## Supported Files
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,8 +169,11 @@ fn test_re_keyword_ignore_file() {
     let re = re_keyword_ignore_file();
     for line in [
         "  #   keepsorted  : ignore   file  .  ",
+        "#keepsorted:ignore file",
         "  //   keepsorted  : ignore   file  .  ",
+        "//keepsorted:ignore file",
         "  --   keepsorted  : ignore   file  .  ",
+        "--keepsorted:ignore file",
     ] {
         assert!(
             re.is_match(line),
@@ -190,8 +193,11 @@ fn test_re_keyword_ignore_block() {
     let re = re_keyword_ignore_block();
     for line in [
         "  #   keepsorted  : ignore   block  .  ",
+        "#keepsorted:ignore block",
         "  //   keepsorted  : ignore   block  .  ",
+        "//keepsorted:ignore block",
         "  --   keepsorted  : ignore   block  .  ",
+        "--keepsorted:ignore block",
     ] {
         assert!(
             re.is_match(line),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ fn test_re_keyword_keep_sorted() {
 }
 
 fn re_keyword_ignore_file() -> Regex {
-    Regex::new(r"(?i)^\s*(#|\/\/)\s*keepsorted\s*:\s*ignore\s+file\s*\.?\s*$")
+    Regex::new(r"(?i)^\s*(#|\/\/|--)\s*keepsorted\s*:\s*ignore\s+file\s*\.?\s*$")
         .expect("Failed to build regex for ignore file")
 }
 
@@ -170,6 +170,7 @@ fn test_re_keyword_ignore_file() {
     for line in [
         "  #   keepsorted  : ignore   file  .  ",
         "  //   keepsorted  : ignore   file  .  ",
+        "  --   keepsorted  : ignore   file  .  ",
     ] {
         assert!(
             re.is_match(line),
@@ -180,7 +181,7 @@ fn test_re_keyword_ignore_file() {
 }
 
 fn re_keyword_ignore_block() -> Regex {
-    Regex::new(r"(?i)^\s*(#|\/\/)\s*keepsorted\s*:\s*ignore\s+block\s*\.?\s*$")
+    Regex::new(r"(?i)^\s*(#|\/\/|--)\s*keepsorted\s*:\s*ignore\s+block\s*\.?\s*$")
         .expect("Failed to build regex for ignore block")
 }
 
@@ -190,6 +191,7 @@ fn test_re_keyword_ignore_block() {
     for line in [
         "  #   keepsorted  : ignore   block  .  ",
         "  //   keepsorted  : ignore   block  .  ",
+        "  --   keepsorted  : ignore   block  .  ",
     ] {
         assert!(
             re.is_match(line),


### PR DESCRIPTION
## Summary
- recognize `--` comment prefix for ignore file/block directives
- test the new patterns
- mention Lua comment style in README without repeating examples

## Testing
- `cargo +1.76.0-x86_64-unknown-linux-gnu test --offline` *(fails: could not download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6874a003014c832d81dd71c4b3559d79