### PR TITLE
feat: add check mode for linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,13 @@ $ keepsorted <path> --features rust_derive_canonical
 
 The feature is inspired by a closed ticket to update rust style, [link](https://github.com/rust-lang/style-team/issues/154).
 
+### Check mode
+
+Use `--check` to verify that a file is already sorted without modifying it.
+The command exits with status `0` when no changes are needed and `1` otherwise.
+
+```shell
+$ keepsorted --check Cargo.toml
+```
+
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::fs::{self, File};
-use std::io::{self, BufWriter, Write};
+use std::fs;
+use std::io::{self};
 use std::path::Path;
 
 mod strategies;
@@ -12,10 +12,10 @@ static RE_KEEP_SORTED: Lazy<Regex> = Lazy::new(re_keyword_keep_sorted);
 static RE_IGNORE_FILE: Lazy<Regex> = Lazy::new(re_keyword_ignore_file);
 static RE_IGNORE_BLOCK: Lazy<Regex> = Lazy::new(re_keyword_ignore_block);
 
-/// Sorts a file in place using an appropriate strategy.
+/// Returns the sorted content of a file using an appropriate strategy.
 ///
 /// The `features` list enables optional experimental strategies.
-pub fn process_file(path: &Path, features: Vec<String>) -> io::Result<()> {
+pub fn process_file(path: &Path, features: Vec<String>) -> io::Result<String> {
     let mut content = fs::read_to_string(path)?;
     let ends_with_newline = content.ends_with('\n');
     if !ends_with_newline {
@@ -26,21 +26,16 @@ pub fn process_file(path: &Path, features: Vec<String>) -> io::Result<()> {
     let lines: Vec<_> = content.split_inclusive('\n').map(String::from).collect();
     let output_lines = process_lines(classify(path, features), lines)?;
 
-    let mut writer = BufWriter::new(File::create(path)?);
+    let mut result = String::new();
     for (i, line) in output_lines.iter().enumerate() {
-        write!(
-            writer,
-            "{}",
-            if i + 1 == output_lines.len() && !ends_with_newline {
-                // Remove the newline if it wasn’t in the original.
-                line.trim_end_matches('\n')
-            } else {
-                line
-            }
-        )?;
+        if i + 1 == output_lines.len() && !ends_with_newline {
+            result.push_str(line.trim_end_matches('\n'));
+        } else {
+            result.push_str(line);
+        }
     }
 
-    writer.flush()
+    Ok(result)
 }
 
 /// Available sorting strategies.

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,10 @@ struct Args {
         help = "Experimental feature flags. Provide a list of features to enable."
     )]
     features: Option<Vec<String>>,
+
+    /// Only check whether the file is sorted. Exit with code 1 if changes are needed.
+    #[arg(long)]
+    check: bool,
 }
 
 fn main() -> io::Result<()> {
@@ -66,7 +70,7 @@ fn main() -> io::Result<()> {
 
     // Check for experimental features
     let features = args.features.unwrap_or_default();
-    process_file(path, features).map_err(|e| {
+    let sorted = process_file(path, features).map_err(|e| {
         eprintln!(
             "{}: failed to process file {}: {}",
             env!("CARGO_PKG_NAME"),
@@ -74,5 +78,16 @@ fn main() -> io::Result<()> {
             e
         );
         e
-    })
+    })?;
+
+    if args.check {
+        let original = std::fs::read_to_string(path)?;
+        if original != sorted {
+            std::process::exit(1);
+        }
+    } else {
+        std::fs::write(path, sorted)?;
+    }
+
+    Ok(())
 }

--- a/tests/e2e-tests.rs
+++ b/tests/e2e-tests.rs
@@ -56,6 +56,42 @@ fn run_test(input_file_path: &str, expected_file_path: &str, features: &str) {
     );
 }
 
+fn run_check_test(input_file_path: &str, features: &str, expect_success: bool) {
+    let input_content = fs::read_to_string(input_file_path).expect("Failed to read input file");
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+    let temp_input_file_path = temp_dir
+        .path()
+        .join(Path::new(input_file_path).file_name().unwrap());
+    fs::write(&temp_input_file_path, &input_content).expect("Failed to write to temporary file");
+
+    let keepsorted_binary = if cfg!(debug_assertions) {
+        "./target/debug/keepsorted"
+    } else {
+        "./target/release/keepsorted"
+    };
+    let mut command = Command::new(keepsorted_binary);
+    command
+        .arg("--check")
+        .arg(temp_input_file_path.to_str().unwrap());
+    if !features.is_empty() {
+        command.arg("--features").arg(features);
+    }
+
+    let output = command.output().expect("Failed to execute keepsorted");
+    if expect_success {
+        assert!(output.status.success(), "keepsorted --check should succeed");
+    } else {
+        assert!(!output.status.success(), "keepsorted --check should fail");
+    }
+
+    let output_content =
+        fs::read_to_string(&temp_input_file_path).expect("Failed to read output file");
+    assert_eq!(
+        input_content, output_content,
+        "--check should not modify the file"
+    );
+}
+
 fn dir(path: &str) -> String {
     format!("./tests/e2e-tests/{path}")
 }
@@ -146,4 +182,14 @@ fn test_e2e_rust_derive_3() {
         &dir("rust_derive/3_out.rs"),
         "rust_derive_alphabetical",
     );
+}
+
+#[test]
+fn test_check_fails_on_unsorted() {
+    run_check_test(&dir("generic/1_in.txt"), "", false);
+}
+
+#[test]
+fn test_check_succeeds_on_sorted() {
+    run_check_test(&dir("generic/1_out.txt"), "", true);
 }


### PR DESCRIPTION
## Summary
- add `--check` flag to CLI so the tool can lint without modifying files
- update library API to return sorted content
- implement check logic in `main` and update docs
- extend e2e tests to cover `--check` behavior

## Testing
- `cargo check`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build --release --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_687558dc54a4832d8348c58f3669ef8f