### PR TITLE
docs: update docs for v0.1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 - (add updates here)
 
+## [0.1.4] - 2025-07-14
+
+### Fixed
+- Correct Bazel file detection
+- Support Lua-style `--` comments for ignore directives
+
+### Documentation
+- Fix link in the development guide
+- Fix numbering in the publish guide
+
+### Misc
+- Added license file
+- Corrected alphabetical sort function typo
+
+## [0.1.3] - 2025-07-10
+
+### Added
+- Support for Lua files
+
+### Fixed
+- Improved `rust_derive` and generic sorting interaction
+
+### CI
+- Simplified workflow configuration
+
 ## [0.1.2] - 2025-06-03
 
 ### Fixed

--- a/development-guide.md
+++ b/development-guide.md
@@ -16,7 +16,8 @@ This guide describes how to prepare and publish a new release of the `keepsorted
    - Title: `vX.X.X`
    - Previous tag: last release
    - Notes: click **Generate release notes**, edit if needed
-4. Click **Publish release**.
+4. Summarize the highlights and add them to `CHANGELOG.md`.
+5. Click **Publish release**.
 
 ## 3. Publish to crates.io
 


### PR DESCRIPTION
## Summary
- document changes for 0.1.3 and 0.1.4
- remind maintainers to summarise highlights in the changelog when drafting a release

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68755c736b0c832d9b949eacc8e1c4d4