### PR TITLE
feat(cli): add mode enum and replace --check

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 `keepsorted` is a command-line tool that helps you sort blocks of lines in your code files.
 
 It works by sorting lines within a block that starts with the activation comment `# Keep sorted`.
+The idea is inspired by the Bazel build tool's **buildifier**, which sorts lists marked with that comment.
+Unlike buildifier, `keepsorted` can apply this rule to any text file.
 In some files, like `Cargo.toml`, it sorts automatically without needing an activation comment.
 
 The tool can also recognize comments attached to non-comment lines, like this:
@@ -139,11 +141,11 @@ The feature is inspired by a closed ticket to update rust style, [link](https://
 
 ### Check mode
 
-Use `--check` to verify that a file is already sorted without modifying it.
+Use `--mode check` to verify that a file is already sorted without modifying it.
 The command exits with status `0` when no changes are needed and `1` otherwise.
 
 ```shell
-$ keepsorted --check Cargo.toml
+$ keepsorted --mode check Cargo.toml
 ```
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{arg, command, Parser};
+use clap::{arg, command, Parser, ValueEnum};
 use keepsorted::process_file;
 use std::io::{self};
 use std::path::Path;
@@ -9,6 +9,12 @@ fn about() -> String {
         env!("CARGO_PKG_DESCRIPTION"),
         env!("CARGO_PKG_REPOSITORY")
     )
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Mode {
+    Check,
+    Fix,
 }
 
 #[derive(Debug, Parser)]
@@ -43,9 +49,14 @@ struct Args {
     )]
     features: Option<Vec<String>>,
 
-    /// Only check whether the file is sorted. Exit with code 1 if changes are needed.
-    #[arg(long)]
-    check: bool,
+    #[arg(
+        short = 'm',
+        long,
+        value_enum,
+        default_value_t = Mode::Fix,
+        help = "Operation mode: 'check' verifies sorting without writing"
+    )]
+    mode: Mode,
 }
 
 fn main() -> io::Result<()> {
@@ -80,13 +91,16 @@ fn main() -> io::Result<()> {
         e
     })?;
 
-    if args.check {
-        let original = std::fs::read_to_string(path)?;
-        if original != sorted {
-            std::process::exit(1);
+    match args.mode {
+        Mode::Check => {
+            let original = std::fs::read_to_string(path)?;
+            if original != sorted {
+                std::process::exit(1);
+            }
         }
-    } else {
-        std::fs::write(path, sorted)?;
+        Mode::Fix => {
+            std::fs::write(path, sorted)?;
+        }
     }
 
     Ok(())

--- a/tests/e2e-tests.rs
+++ b/tests/e2e-tests.rs
@@ -71,7 +71,8 @@ fn run_check_test(input_file_path: &str, features: &str, expect_success: bool) {
     };
     let mut command = Command::new(keepsorted_binary);
     command
-        .arg("--check")
+        .arg("--mode")
+        .arg("check")
         .arg(temp_input_file_path.to_str().unwrap());
     if !features.is_empty() {
         command.arg("--features").arg(features);
@@ -79,16 +80,23 @@ fn run_check_test(input_file_path: &str, features: &str, expect_success: bool) {
 
     let output = command.output().expect("Failed to execute keepsorted");
     if expect_success {
-        assert!(output.status.success(), "keepsorted --check should succeed");
+        assert!(
+            output.status.success(),
+            "keepsorted --mode check should succeed"
+        );
     } else {
-        assert!(!output.status.success(), "keepsorted --check should fail");
+        assert!(
+            !output.status.success(),
+            "keepsorted --mode check should fail"
+        );
     }
 
     let output_content =
         fs::read_to_string(&temp_input_file_path).expect("Failed to read output file");
     assert_eq!(
-        input_content, output_content,
-        "--check should not modify the file"
+        input_content,
+        output_content,
+        "--mode check should not modify the file"
     );
 }
 


### PR DESCRIPTION
## Summary
- add `Mode` enum and parse `--mode` argument
- replace `check` bool with `mode` enum in `Args`
- use `args.mode` when applying changes or verifying sorted state
- update e2e tests for `--mode check`
- document new `--mode` flag and mention buildifier inspiration

## Testing
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_68828c8772d0832d9aef6a4711fac5e7