### PR TITLE
feat(cli): support diff formatting mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["sorting", "code", "command-line"]
 clap = { version = "4.0", features = ["derive"] }
 once_cell = "1.19.0"
 regex = "1"
+similar = "2.7.0"
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/README.md
+++ b/README.md
@@ -140,10 +140,11 @@ The feature is inspired by a closed ticket to update rust style, [link](https://
 
 ### Formatting mode
 
-The `--mode` option controls whether the file is modified. It accepts `check` or
-`fix` (the default).
+The `--mode` option controls whether the file is modified. It accepts `check`,
+`diff`, or `fix` (the default).
 
 Use `--mode check` to verify that a file is already sorted without modifying it.
+Use `--mode diff` to print a unified diff of the required changes.
 Use `--mode fix` to rewrite the file in place.
 
 The command exits with these codes:
@@ -152,6 +153,7 @@ The command exits with these codes:
 
 ```shell
 $ keepsorted --mode check Cargo.toml
+$ keepsorted --mode diff Cargo.toml
 $ keepsorted --mode fix Cargo.toml
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,12 @@ use keepsorted::process_file;
 use std::io::{self};
 use std::path::Path;
 
+/// Exit code used when sorting is required or an error occurs.
+const EXIT_CHANGES_NEEDED: i32 = 1;
+
 fn about() -> String {
     format!(
-        "{}\nThis tool sorts lines in blocks marked with '# Keep sorted'. Use --mode fix or --mode check and enable extra features with flags. {}",
+        "{}\nThis tool sorts lines in blocks marked with '# Keep sorted'. Use --mode check, --mode diff, or --mode fix and enable extra features with flags. {}",
         env!("CARGO_PKG_DESCRIPTION"),
         env!("CARGO_PKG_REPOSITORY")
     )
@@ -16,6 +19,8 @@ fn about() -> String {
 enum Mode {
     /// Verify that the file is already sorted.
     Check,
+    /// Print a diff of the required changes.
+    Diff,
     /// Rewrite the file with sorted content.
     Fix,
 }
@@ -52,13 +57,13 @@ struct Args {
     )]
     features: Option<Vec<String>>,
 
-    /// Formatting mode: check or fix (default fix)
+    /// Formatting mode: check, diff, or fix (default fix)
     #[arg(
         short = 'm',
         long,
         value_enum,
         default_value_t = Mode::Fix,
-        help = "formatting mode: check or fix (default fix)"
+        help = "formatting mode: check, diff, or fix (default fix)"
     )]
     mode: Mode,
 }
@@ -80,7 +85,7 @@ fn main() -> io::Result<()> {
             env!("CARGO_PKG_NAME"),
             path.display()
         );
-        std::process::exit(1);
+        std::process::exit(EXIT_CHANGES_NEEDED);
     }
 
     // Check for experimental features
@@ -99,7 +104,18 @@ fn main() -> io::Result<()> {
         Mode::Check => {
             let original = std::fs::read_to_string(path)?;
             if original != sorted {
-                std::process::exit(1);
+                std::process::exit(EXIT_CHANGES_NEEDED);
+            }
+        }
+        Mode::Diff => {
+            let original = std::fs::read_to_string(path)?;
+            if original != sorted {
+                use similar::TextDiff;
+                let diff = TextDiff::from_lines(&original, &sorted);
+                let old = format!("a/{}", path.display());
+                let new = format!("b/{}", path.display());
+                print!("{}", diff.unified_diff().header(&old, &new));
+                std::process::exit(EXIT_CHANGES_NEEDED);
             }
         }
         Mode::Fix => {

--- a/tests/e2e-tests.rs
+++ b/tests/e2e-tests.rs
@@ -15,14 +15,19 @@ fn run_test(
     let expected_content = fs::read_to_string(expected_file_path)
         .unwrap_or_else(|_| panic!("Failed to read expected file: {}", expected_file_path));
 
-    // Create a temporary directory
-    let temp_dir = tempdir().expect("Failed to create temporary directory");
-    let temp_input_file_path = temp_dir
-        .path()
-        .join(Path::new(input_file_path).file_name().unwrap());
-
-    // Write the input content to a temporary file
-    fs::write(&temp_input_file_path, &input_content).expect("Failed to write to temporary file");
+    let (run_path, _temp_dir): (std::path::PathBuf, Option<tempfile::TempDir>);
+    if mode == "diff" {
+        run_path = Path::new(input_file_path).to_path_buf();
+        _temp_dir = None;
+    } else {
+        let td = tempdir().expect("Failed to create temporary directory");
+        let tmp = td
+            .path()
+            .join(Path::new(input_file_path).file_name().unwrap());
+        fs::write(&tmp, &input_content).expect("Failed to write to temporary file");
+        run_path = tmp;
+        _temp_dir = Some(td);
+    }
 
     // Determine the path to the keepsorted binary based on the build mode
     let keepsorted_binary = if cfg!(debug_assertions) {
@@ -35,7 +40,7 @@ fn run_test(
     command
         .arg("--mode")
         .arg(mode)
-        .arg(temp_input_file_path.to_str().unwrap());
+        .arg(run_path.to_str().unwrap());
     if !features.is_empty() {
         command.arg("--features").arg(features);
     }
@@ -54,19 +59,24 @@ fn run_test(
     }
 
     // Read the content of the temporary file after running keepsorted
-    let output_content =
-        fs::read_to_string(&temp_input_file_path).expect("Failed to read output file");
+    let output_content = fs::read_to_string(&run_path).expect("Failed to read output file");
 
     if mode == "fix" {
         assert_eq!(
             output_content, expected_content,
-            "The output content does not match the expected content"
+            "The output content does not match the expected content",
         );
     } else {
         assert_eq!(
             output_content, input_content,
-            "--mode check should not modify the file"
+            "--mode {} should not modify the file",
+            mode
         );
+    }
+
+    if mode == "diff" {
+        let diff_output = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(diff_output, expected_content, "Diff output mismatch");
     }
 
     // Ensure the input file is not modified
@@ -232,6 +242,28 @@ fn test_check_succeeds_on_sorted() {
         &dir("generic/1_out.txt"),
         "",
         "check",
+        true,
+    );
+}
+
+#[test]
+fn test_diff_fails_on_unsorted() {
+    run_test(
+        &dir("bazel/1_in.bazel"),
+        &dir("bazel/1_out_diff.bazel"),
+        "",
+        "diff",
+        false,
+    );
+}
+
+#[test]
+fn test_diff_succeeds_on_sorted() {
+    run_test(
+        &dir("bazel/1_out.bazel"),
+        &dir("bazel/1_out_diff_empty.bazel"),
+        "",
+        "diff",
         true,
     );
 }

--- a/tests/e2e-tests/bazel/1_out_diff.bazel
+++ b/tests/e2e-tests/bazel/1_out_diff.bazel
@@ -1,0 +1,44 @@
+--- a/./tests/e2e-tests/bazel/1_in.bazel
++++ b/./tests/e2e-tests/bazel/1_in.bazel
+@@ -5,32 +5,32 @@
+     ],
+     proc_macro_deps = [
+         # Keep sorted.
+-        ":bbb",
+         ":aaa",
+-        "//dir/subdir:bbb",
++        ":bbb",
+         "//dir/subdir:aaa",
+-        "@crate_index//:bbb",
++        "//dir/subdir:bbb",
+         "@crate_index//:aaa",
++        "@crate_index//:bbb",
+     ] + select({
+         "@platforms//os:osx": [
+             # Keep sorted.
++            ":aaa",
+             ":bbb",
+-            ":aaa",
++            "//dir/subdir:aaa",
+             "//dir/subdir:bbb",
+-            "//dir/subdir:aaa",
+-            "@crate_index//:bbb",
+             "@crate_index//:aaa",
++            "@crate_index//:bbb",
+         ],
+         "//conditions:default": [
+         ],
+     }),
+     deps = [
+         # Keep sorted.
+-        ":bbb",
+         ":aaa",
+-        "//dir/subdir:bbb",
++        ":bbb",
+         "//dir/subdir:aaa",
++        "//dir/subdir:bbb",
++        "@crate_index//:aaa",
+         "@crate_index//:bbb",
+-        "@crate_index//:aaa",
+     ],
+ )


### PR DESCRIPTION
## Summary
- implement diff mode
- adjust exit codes and tests
- clarify exit code comment per review

## Testing
- `cargo build --quiet`
- `cargo test --quiet`
- `cargo test --release --quiet`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_6882a5e3dc78832dae6dc16a249333e0