### PR TITLE
feat: implement buildifier-style exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,11 @@ Use `--mode diff` to print a unified diff of the required changes.
 Use `--mode fix` to rewrite the file in place.
 
 The command exits with these codes:
-1. `0` — no changes were needed
-2. `1` — the file requires sorting or an error occurred
+1. `0` — success
+2. `1` — syntax errors in input
+3. `2` — usage errors
+4. `3` — unexpected runtime errors
+5. `4` — check mode failed (reformat is needed)
 
 ```shell
 $ keepsorted --mode check Cargo.toml

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use clap::{arg, command, Parser, ValueEnum};
 use keepsorted::process_file;
-use std::io::{self};
 use std::path::Path;
+use std::process;
 
-/// Exit code used when sorting is required or an error occurs.
-const EXIT_CHANGES_NEEDED: i32 = 1;
+/// Exit code used for I/O problems or internal bugs.
+const EXIT_RUNTIME_ERROR: i32 = 3;
+/// Exit code used when `--mode check` or `--mode diff` detects unsorted files.
+const EXIT_CHECK_FAILED: i32 = 4;
 
 fn about() -> String {
     format!(
@@ -68,7 +70,7 @@ struct Args {
     mode: Mode,
 }
 
-fn main() -> io::Result<()> {
+fn main() {
     let args = Args::parse();
 
     // Get the path from either the option or the positional argument
@@ -85,43 +87,74 @@ fn main() -> io::Result<()> {
             env!("CARGO_PKG_NAME"),
             path.display()
         );
-        std::process::exit(EXIT_CHANGES_NEEDED);
+        process::exit(EXIT_RUNTIME_ERROR);
     }
 
     // Check for experimental features
     let features = args.features.unwrap_or_default();
-    let sorted = process_file(path, features).map_err(|e| {
-        eprintln!(
-            "{}: failed to process file {}: {}",
-            env!("CARGO_PKG_NAME"),
-            path.display(),
-            e
-        );
-        e
-    })?;
+    let sorted = match process_file(path, features) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "{}: failed to process file {}: {}",
+                env!("CARGO_PKG_NAME"),
+                path.display(),
+                e
+            );
+            process::exit(EXIT_RUNTIME_ERROR);
+        }
+    };
 
     match args.mode {
         Mode::Check => {
-            let original = std::fs::read_to_string(path)?;
+            let original = match std::fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!(
+                        "{}: failed to read file {}: {}",
+                        env!("CARGO_PKG_NAME"),
+                        path.display(),
+                        e
+                    );
+                    process::exit(EXIT_RUNTIME_ERROR);
+                }
+            };
             if original != sorted {
-                std::process::exit(EXIT_CHANGES_NEEDED);
+                process::exit(EXIT_CHECK_FAILED);
             }
         }
         Mode::Diff => {
-            let original = std::fs::read_to_string(path)?;
+            let original = match std::fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!(
+                        "{}: failed to read file {}: {}",
+                        env!("CARGO_PKG_NAME"),
+                        path.display(),
+                        e
+                    );
+                    process::exit(EXIT_RUNTIME_ERROR);
+                }
+            };
             if original != sorted {
                 use similar::TextDiff;
                 let diff = TextDiff::from_lines(&original, &sorted);
                 let old = format!("a/{}", path.display());
                 let new = format!("b/{}", path.display());
                 print!("{}", diff.unified_diff().header(&old, &new));
-                std::process::exit(EXIT_CHANGES_NEEDED);
+                process::exit(EXIT_CHECK_FAILED);
             }
         }
         Mode::Fix => {
-            std::fs::write(path, sorted)?;
+            if let Err(e) = std::fs::write(path, sorted) {
+                eprintln!(
+                    "{}: failed to write file {}: {}",
+                    env!("CARGO_PKG_NAME"),
+                    path.display(),
+                    e
+                );
+                process::exit(EXIT_RUNTIME_ERROR);
+            }
         }
     }
-
-    Ok(())
 }


### PR DESCRIPTION
## Summary
- add explicit constants for new return codes
- exit with code 3 on runtime errors and code 4 when check/diff fails
- document new codes in README

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -co --exclude-standard | grep -vE "^misc/|^tests/|^README.md" | xargs -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}`
- `git diff --exit-code`

------
https://chatgpt.com/codex/tasks/task_e_68832f6bbf94832db82fad2808241512