### PR TITLE
feat(cli): add recursive flag

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,26 @@
+# Instructions for AI Agent
+
+## PR Naming
+- Name GitHub pull requests using the **Conventional Commits** specification. Example: `feat(parser): support new syntax` or `fix(ci): correct clippy invocation`.
+
+## Validation Steps
+- Before submitting a PR, run each command from `./run-all.sh` manually. It may
+  include:
+  - `cargo build --release --all-targets`
+  - `cargo test`
+  - `cargo test --release`
+  - `cargo clippy --all-targets -- -D warnings`
+  - `cargo fmt --all -- --check`
+  - running `keepsorted` over tracked files
+- After running the individual commands, execute `./run-all.sh` to confirm that
+  no further changes are introduced and that all steps succeed. Always consult
+  the script for updates.
+  - The PR fails if any command fails or if `git diff` shows changes
+
+## Best Practices
+- Use the Rust version pinned in `rust-toolchain.toml`.
+- Always format code using `cargo fmt`.
+- Address warnings reported by `cargo clippy` as invoked in `run-all.sh`.
+- Keep entries in `Cargo.toml` and other marked blocks sorted using `keepsorted` comments.
+- Update `CHANGELOG.md` for user‑visible changes following the Keep a Changelog format.
+- Commit messages should also follow the Conventional Commits style.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "4.0", features = ["derive"] }
 once_cell = "1.19.0"
 regex = "1"
 similar = "2.7.0"
+walkdir = "2.5.0"
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Use `--mode fix` (or `--fix`) to rewrite the file in place.
 The command exits with these codes:
 1. `0` — success
 2. `1` — syntax errors in input
-3. `2` — usage errors
+3. `2` — usage errors: invoked incorrectly
 4. `3` — unexpected runtime errors
 5. `4` — check mode failed (reformat is needed)
 
@@ -159,6 +159,15 @@ The command exits with these codes:
 $ keepsorted --check Cargo.toml
 $ keepsorted --diff Cargo.toml
 $ keepsorted --fix Cargo.toml
+```
+
+### Recursive mode
+
+Use `--recursive` (or `-r`) to walk a directory and process every file inside it.
+Without this flag, passing a directory path results in an error.
+
+```shell
+$ keepsorted -r path/to/project
 ```
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,10 +140,8 @@ fn main() {
         }
 
         for entry in WalkDir::new(path).into_iter().filter_map(Result::ok) {
-            if entry.file_type().is_file() {
-                if !handle_file(entry.path(), &features, mode) {
-                    exit_code = EXIT_CHECK_FAILED;
-                }
+            if entry.file_type().is_file() && !handle_file(entry.path(), &features, mode) {
+                exit_code = EXIT_CHECK_FAILED;
             }
         }
     } else if !handle_file(path, &features, mode) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,12 @@ use clap::{arg, command, Parser, ValueEnum};
 use keepsorted::process_file;
 use std::path::Path;
 use std::process;
+use walkdir::WalkDir;
 
+/// Exit code used when the command is invoked incorrectly.
+///
+/// clap also exits with this code on usage errors such as conflicting flags.
+const EXIT_USAGE_ERROR: i32 = 2;
 /// Exit code used for I/O problems or internal bugs.
 const EXIT_RUNTIME_ERROR: i32 = 3;
 /// Exit code used when `--mode check` or `--mode diff` detects unsorted files.
@@ -58,6 +63,10 @@ struct Args {
         help = "Experimental feature flags. Provide a list of features to enable."
     )]
     features: Option<Vec<String>>,
+
+    /// Recursively process directories
+    #[arg(short = 'r', long, help = "Recursively process directories")]
+    recursive: bool,
 
     /// Verify that the file is already sorted
     #[arg(
@@ -116,18 +125,38 @@ fn main() {
 
     let path = Path::new(&file_path);
 
-    if path.is_dir() {
-        eprintln!(
-            "{}: read {}: is a directory",
-            env!("CARGO_PKG_NAME"),
-            path.display()
-        );
-        process::exit(EXIT_RUNTIME_ERROR);
-    }
-
     // Check for experimental features
     let features = args.features.unwrap_or_default();
-    let sorted = match process_file(path, features) {
+    let mut exit_code = 0;
+
+    if path.is_dir() {
+        if !args.recursive {
+            eprintln!(
+                "{}: read {}: is a directory",
+                env!("CARGO_PKG_NAME"),
+                path.display()
+            );
+            process::exit(EXIT_USAGE_ERROR);
+        }
+
+        for entry in WalkDir::new(path).into_iter().filter_map(Result::ok) {
+            if entry.file_type().is_file() {
+                if !handle_file(entry.path(), &features, mode) {
+                    exit_code = EXIT_CHECK_FAILED;
+                }
+            }
+        }
+    } else if !handle_file(path, &features, mode) {
+        exit_code = EXIT_CHECK_FAILED;
+    }
+
+    if exit_code != 0 {
+        process::exit(exit_code);
+    }
+}
+
+fn handle_file(path: &Path, features: &[String], mode: Mode) -> bool {
+    let sorted = match process_file(path, features.to_vec()) {
         Ok(s) => s,
         Err(e) => {
             eprintln!(
@@ -154,9 +183,7 @@ fn main() {
                     process::exit(EXIT_RUNTIME_ERROR);
                 }
             };
-            if original != sorted {
-                process::exit(EXIT_CHECK_FAILED);
-            }
+            original == sorted
         }
         Mode::Diff => {
             let original = match std::fs::read_to_string(path) {
@@ -177,8 +204,9 @@ fn main() {
                 let old = format!("a/{}", path.display());
                 let new = format!("b/{}", path.display());
                 print!("{}", diff.unified_diff().header(&old, &new));
-                process::exit(EXIT_CHECK_FAILED);
+                return false;
             }
+            true
         }
         Mode::Fix => {
             if let Err(e) = std::fs::write(path, sorted) {
@@ -190,6 +218,7 @@ fn main() {
                 );
                 process::exit(EXIT_RUNTIME_ERROR);
             }
+            true
         }
     }
 }

--- a/tests/e2e-tests.rs
+++ b/tests/e2e-tests.rs
@@ -309,3 +309,28 @@ fn test_shorthand_fix() {
         true,
     );
 }
+
+#[test]
+fn test_directory_without_recursive_flag_fails() {
+    let td = tempdir().expect("Failed to create temporary directory");
+    fs::write(
+        td.path().join("file.txt"),
+        fs::read_to_string(dir("generic/1_in.txt")).unwrap(),
+    )
+    .unwrap();
+    let keepsorted_binary = if cfg!(debug_assertions) {
+        "./target/debug/keepsorted"
+    } else {
+        "./target/release/keepsorted"
+    };
+    let output = Command::new(keepsorted_binary)
+        .args(["--mode", "fix"])
+        .arg(td.path())
+        .output()
+        .expect("Failed to execute keepsorted");
+    assert_eq!(
+        output.status.code().unwrap_or_default(),
+        2,
+        "expected usage error exit code"
+    );
+}


### PR DESCRIPTION
This PR adds `--recursive` (or `-r`) flag to walk a directory and process every file inside it.
Without this flag, passing a directory path results in an error.

------
https://chatgpt.com/codex/tasks/task_e_6883348c1850832db866eb64d0c935e0