### PR TITLE
feat(cli): add --diff-command option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
- - Added `--mode` option with `check`, `diff`, and `fix` variants and added `--check`, `--diff`, and `--fix` convenience flags
+- Added `--mode` option with `check`, `diff`, and `fix` variants and added `--check`, `--diff`, and `--fix` convenience flags
+- Added `--diff-command` option to run a custom program when showing diffs
 
 ## [0.1.5] - 2025-07-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ keywords = ["sorting", "code", "command-line"]
 clap = { version = "4.0", features = ["derive"] }
 once_cell = "1.19.0"
 regex = "1"
+shell-words = "1.1.0"
 similar = "2.7.0"
+tempfile = "3.2"
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ aliases for `--mode check`, `--mode diff`, and `--mode fix` respectively.
 
 Use `--mode check` (or `--check`) to verify that a file is already sorted without modifying it.
 Use `--mode diff` (or `--diff`) to print a unified diff of the required changes.
+Use `--diff-command <command>` to delegate diff generation to an external program.
 Use `--mode fix` (or `--fix`) to rewrite the file in place.
 
 The command exits with these codes:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{arg, command, Parser, ValueEnum};
 use keepsorted::process_file;
 use std::path::Path;
-use std::process;
+use std::process::{self, Command};
 use walkdir::WalkDir;
 
 /// Exit code used when the command is invoked incorrectly.
@@ -102,6 +102,14 @@ struct Args {
         help = "formatting mode: check, diff, or fix (default fix)"
     )]
     mode: Mode,
+
+    /// Command to run to display diffs
+    #[arg(
+        long,
+        value_name = "COMMAND",
+        help = "command to run when the formatting mode is diff"
+    )]
+    diff_command: Option<String>,
 }
 
 fn main() {
@@ -140,11 +148,13 @@ fn main() {
         }
 
         for entry in WalkDir::new(path).into_iter().filter_map(Result::ok) {
-            if entry.file_type().is_file() && !handle_file(entry.path(), &features, mode) {
+            if entry.file_type().is_file()
+                && !handle_file(entry.path(), &features, mode, args.diff_command.as_deref())
+            {
                 exit_code = EXIT_CHECK_FAILED;
             }
         }
-    } else if !handle_file(path, &features, mode) {
+    } else if !handle_file(path, &features, mode, args.diff_command.as_deref()) {
         exit_code = EXIT_CHECK_FAILED;
     }
 
@@ -153,7 +163,7 @@ fn main() {
     }
 }
 
-fn handle_file(path: &Path, features: &[String], mode: Mode) -> bool {
+fn handle_file(path: &Path, features: &[String], mode: Mode, diff_command: Option<&str>) -> bool {
     let sorted = match process_file(path, features.to_vec()) {
         Ok(s) => s,
         Err(e) => {
@@ -197,12 +207,65 @@ fn handle_file(path: &Path, features: &[String], mode: Mode) -> bool {
                 }
             };
             if original != sorted {
-                use similar::TextDiff;
-                let diff = TextDiff::from_lines(&original, &sorted);
-                let old = format!("a/{}", path.display());
-                let new = format!("b/{}", path.display());
-                print!("{}", diff.unified_diff().header(&old, &new));
-                return false;
+                if let Some(cmd) = diff_command {
+                    use tempfile::NamedTempFile;
+                    let tmp = NamedTempFile::new().expect("create temp file");
+                    if let Err(e) = std::fs::write(tmp.path(), &sorted) {
+                        eprintln!(
+                            "{}: failed to write temp file {}: {}",
+                            env!("CARGO_PKG_NAME"),
+                            tmp.path().display(),
+                            e
+                        );
+                        process::exit(EXIT_RUNTIME_ERROR);
+                    }
+                    let parts = match shell_words::split(cmd) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            eprintln!(
+                                "{}: failed to parse diff command '{}': {}",
+                                env!("CARGO_PKG_NAME"),
+                                cmd,
+                                e
+                            );
+                            process::exit(EXIT_RUNTIME_ERROR);
+                        }
+                    };
+                    let (prog, args) = parts.split_first().unwrap_or_else(|| {
+                        eprintln!("{}: diff command is empty", env!("CARGO_PKG_NAME"));
+                        process::exit(EXIT_RUNTIME_ERROR);
+                    });
+                    let output = Command::new(prog)
+                        .args(args)
+                        .arg(path)
+                        .arg(tmp.path())
+                        .output();
+                    match output {
+                        Ok(out) => {
+                            print!("{}", String::from_utf8_lossy(&out.stdout));
+                            if !out.status.success() {
+                                process::exit(out.status.code().unwrap_or(EXIT_RUNTIME_ERROR));
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "{}: failed to run diff command '{}': {}",
+                                env!("CARGO_PKG_NAME"),
+                                cmd,
+                                e
+                            );
+                            process::exit(EXIT_RUNTIME_ERROR);
+                        }
+                    }
+                    return false;
+                } else {
+                    use similar::TextDiff;
+                    let diff = TextDiff::from_lines(&original, &sorted);
+                    let old = format!("a/{}", path.display());
+                    let new = format!("b/{}", path.display());
+                    print!("{}", diff.unified_diff().header(&old, &new));
+                    return false;
+                }
             }
             true
         }

--- a/tests/e2e-tests.rs
+++ b/tests/e2e-tests.rs
@@ -278,6 +278,17 @@ fn test_diff_succeeds_on_sorted() {
 }
 
 #[test]
+fn test_diff_with_custom_command() {
+    run_test(
+        &dir("bazel/1_in.bazel"),
+        &dir("bazel/1_out_diff_cmd.bazel"),
+        "",
+        &["--mode", "diff", "--diff-command", "sh -c 'echo executed'"],
+        false,
+    );
+}
+
+#[test]
 fn test_shorthand_check() {
     run_test(
         &dir("generic/1_in.txt"),

--- a/tests/e2e-tests/bazel/1_out_diff_cmd.bazel
+++ b/tests/e2e-tests/bazel/1_out_diff_cmd.bazel
@@ -1,0 +1,1 @@
+executed


### PR DESCRIPTION
## Summary
- add optional `--diff-command` to delegate diff creation
- document the new flag in README and CHANGELOG
- test `--diff-command` via new e2e case
- depend on `shell-words` and `tempfile` crates

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -co --exclude-standard | grep -vE "^misc/|^tests/|^README.md" | xargs -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}`
- `./run-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_6883445f74c8832dae6751af5841b6a9