### PR TITLE
docs(cli): simplify help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 - Added `--mode` option with `check`, `diff`, and `fix` variants and added `--check`, `--diff`, and `--fix` convenience flags
 - Added `--diff-command` option to run a custom program when showing diffs
+- Added project website link at the end of `--help` output
+
+### Documentation
+- Document installation command and provide docs.rs, source code, and issue tracker links near the top of README
 
 ## [0.1.5] - 2025-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Simplified help text and clarified `--diff-command`
 - Added documentation link to Cargo.toml
 - Unified quoting style in help output using single quotes
+- Updated `--diff-command` description to quote '--mode diff'
 
 ### Documentation
 - Document installation command and provide docs.rs, source code, and issue tracker links near the top of README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Added project website link at the end of `--help` output
 - Simplified help text and clarified `--diff-command`
 - Added documentation link to Cargo.toml
+- Unified quoting style in help output using single quotes
 
 ### Documentation
 - Document installation command and provide docs.rs, source code, and issue tracker links near the top of README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Added `--mode` option with `check`, `diff`, and `fix` variants and added `--check`, `--diff`, and `--fix` convenience flags
 - Added `--diff-command` option to run a custom program when showing diffs
 - Added project website link at the end of `--help` output
+- Simplified help text and clarified `--diff-command`
+- Added documentation link to Cargo.toml
 
 ### Documentation
 - Document installation command and provide docs.rs, source code, and issue tracker links near the top of README

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "A tool for sorting blocks of lines in code files"
 authors = ["Maksym Arutyunyan"]
 repository = "https://github.com/maksym-arutyunyan/keepsorted"
+documentation = "https://docs.rs/keepsorted"
 readme = "README.md"
 license = "Apache-2.0"
 keywords = ["sorting", "code", "command-line"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 [![keepsorted on crates.io][cratesio-image]][cratesio]
 [![keepsorted on docs.rs][docsrs-image]][docsrs]
 
+```shell
+cargo install keepsorted
+```
+
+- [Documentation](https://docs.rs/keepsorted)
+- [Source code](https://github.com/maksym-arutyunyan/keepsorted)
+- [Issue tracker](https://github.com/maksym-arutyunyan/keepsorted/issues)
+
 `keepsorted` is a command-line tool that helps you sort blocks of lines in your code files.
 The tool is inspired by the Bazel build tool `buildifier`, which sorts items marked with `# Keep sorted` comments. `keepsorted` brings this functionality to any text file.
 

--- a/e2e-tests/files/help.txt
+++ b/e2e-tests/files/help.txt
@@ -1,19 +1,46 @@
 A tool for sorting blocks of lines in code files
-This tool sorts lines in blocks marked with '# Keep sorted'. Use --mode check (or --check), --mode diff (or --diff), or --mode fix (or --fix) and enable extra features with flags. https://github.com/maksym-arutyunyan/keepsorted
+Sort lines inside '# Keep sorted' blocks. Use --check to verify, --diff to preview, or --fix to apply changes. https://github.com/maksym-arutyunyan/keepsorted
 
 Usage: keepsorted [OPTIONS] [PATH]
 
 Arguments:
-  [PATH]  Path to the file to run on. This is required if the -p option is not used.
+  [PATH]
+          File to process (required if --path is not used)
 
 Options:
-  -p, --path <PATH>             Path to the file to run on. This option is mutually exclusive with the positional path.
-  -f, --features <FEATURE>      Experimental feature flags. Provide a list of features to enable.
-  -r, --recursive               Recursively process directories
-      --check                   alias for `--mode check`
-      --diff                    alias for `--mode diff`
-      --fix                     alias for `--mode fix`
-  -m, --mode <MODE>             formatting mode: check, diff, or fix (default fix) [default: fix] [possible values: check, diff, fix]
-      --diff-command <COMMAND>  command to run when the formatting mode is diff
-  -h, --help                    Print help (see more with '--help')
-  -V, --version                 Print version
+  -p, --path <PATH>
+          File to process (conflicts with positional path)
+
+  -f, --features <FEATURE>
+          Enable experimental features
+
+  -r, --recursive
+          Process directories recursively
+
+      --check
+          alias for `--mode check`
+
+      --diff
+          alias for `--mode diff`
+
+      --fix
+          alias for `--mode fix`
+
+  -m, --mode <MODE>
+          Formatting mode: check, diff, or fix
+          
+          [default: fix]
+
+          Possible values:
+          - check: Verify that the file is already sorted
+          - diff:  Print a diff of the required changes
+          - fix:   Rewrite the file with sorted content
+
+      --diff-command <COMMAND>
+          Custom diff command run in diff mode
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version

--- a/e2e-tests/files/help.txt
+++ b/e2e-tests/files/help.txt
@@ -1,5 +1,5 @@
 A tool for sorting blocks of lines in code files
-Sort lines inside '# Keep sorted' blocks. Use --check to verify, --diff to preview, or --fix to apply changes. https://github.com/maksym-arutyunyan/keepsorted
+Sort lines inside '# Keep sorted' blocks. Use --check to verify, --diff to preview, or --fix to apply changes.
 
 Usage: keepsorted [OPTIONS] [PATH]
 
@@ -17,3 +17,5 @@ Options:
       --diff-command <COMMAND>  Custom diff command run in diff mode
   -h, --help                    Print help (see more with '--help')
   -V, --version                 Print version
+
+For more info, visit: https://github.com/maksym-arutyunyan/keepsorted

--- a/e2e-tests/files/help.txt
+++ b/e2e-tests/files/help.txt
@@ -14,7 +14,7 @@ Options:
       --diff                    alias for '--mode diff'
       --fix                     alias for '--mode fix'
   -m, --mode <MODE>             Formatting mode [default: fix] [possible values: check, diff, fix]
-      --diff-command <COMMAND>  Custom command for --mode diff
+      --diff-command <COMMAND>  Custom command for '--mode diff'
   -h, --help                    Print help (see more with '--help')
   -V, --version                 Print version
 

--- a/e2e-tests/files/help.txt
+++ b/e2e-tests/files/help.txt
@@ -4,15 +4,15 @@ Sort lines inside '# Keep sorted' blocks. Use --check to verify, --diff to previ
 Usage: keepsorted [OPTIONS] [PATH]
 
 Arguments:
-  [PATH]  File to process (required if --path is not used)
+  [PATH]  File to process (required if '--path' is not used)
 
 Options:
   -p, --path <PATH>             File to process (conflicts with positional path)
   -f, --features <FEATURE>      Enable experimental features
   -r, --recursive               Process directories recursively
-      --check                   alias for `--mode check`
-      --diff                    alias for `--mode diff`
-      --fix                     alias for `--mode fix`
+      --check                   alias for '--mode check'
+      --diff                    alias for '--mode diff'
+      --fix                     alias for '--mode fix'
   -m, --mode <MODE>             Formatting mode [default: fix] [possible values: check, diff, fix]
       --diff-command <COMMAND>  Custom command for --mode diff
   -h, --help                    Print help (see more with '--help')

--- a/e2e-tests/files/help.txt
+++ b/e2e-tests/files/help.txt
@@ -4,43 +4,16 @@ Sort lines inside '# Keep sorted' blocks. Use --check to verify, --diff to previ
 Usage: keepsorted [OPTIONS] [PATH]
 
 Arguments:
-  [PATH]
-          File to process (required if --path is not used)
+  [PATH]  File to process (required if --path is not used)
 
 Options:
-  -p, --path <PATH>
-          File to process (conflicts with positional path)
-
-  -f, --features <FEATURE>
-          Enable experimental features
-
-  -r, --recursive
-          Process directories recursively
-
-      --check
-          alias for `--mode check`
-
-      --diff
-          alias for `--mode diff`
-
-      --fix
-          alias for `--mode fix`
-
-  -m, --mode <MODE>
-          Formatting mode: check, diff, or fix
-          
-          [default: fix]
-
-          Possible values:
-          - check: Verify that the file is already sorted
-          - diff:  Print a diff of the required changes
-          - fix:   Rewrite the file with sorted content
-
-      --diff-command <COMMAND>
-          Custom diff command run in diff mode
-
-  -h, --help
-          Print help (see a summary with '-h')
-
-  -V, --version
-          Print version
+  -p, --path <PATH>             File to process (conflicts with positional path)
+  -f, --features <FEATURE>      Enable experimental features
+  -r, --recursive               Process directories recursively
+      --check                   alias for `--mode check`
+      --diff                    alias for `--mode diff`
+      --fix                     alias for `--mode fix`
+  -m, --mode <MODE>             Formatting mode: check, diff, or fix [default: fix] [possible values: check, diff, fix]
+      --diff-command <COMMAND>  Custom diff command run in diff mode
+  -h, --help                    Print help (see more with '--help')
+  -V, --version                 Print version

--- a/e2e-tests/files/help.txt
+++ b/e2e-tests/files/help.txt
@@ -13,8 +13,8 @@ Options:
       --check                   alias for `--mode check`
       --diff                    alias for `--mode diff`
       --fix                     alias for `--mode fix`
-  -m, --mode <MODE>             Formatting mode: check, diff, or fix [default: fix] [possible values: check, diff, fix]
-      --diff-command <COMMAND>  Custom diff command run in diff mode
+  -m, --mode <MODE>             Formatting mode [default: fix] [possible values: check, diff, fix]
+      --diff-command <COMMAND>  Custom command for --mode diff
   -h, --help                    Print help (see more with '--help')
   -V, --version                 Print version
 

--- a/e2e-tests/help_flag.bats
+++ b/e2e-tests/help_flag.bats
@@ -5,5 +5,5 @@ load './helpers.bash'
 @test "test \`-h\` prints help" {
   run_keepsorted -h
   [ "$status" -eq 0 ]
-  diff -u "$FILES_DIR/help.txt" - <<<"$output"
+  diff -u "$FILES_DIR/help.txt" <(printf '%s\n' "$output")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,8 @@ const EXIT_CHECK_FAILED: i32 = 4;
 
 fn about() -> String {
     format!(
-        "{}\nSort lines inside '# Keep sorted' blocks. Use --check to verify, --diff to preview, or --fix to apply changes. {}",
-        env!("CARGO_PKG_DESCRIPTION"),
-        env!("CARGO_PKG_REPOSITORY")
+        "{}\nSort lines inside '# Keep sorted' blocks. Use --check to verify, --diff to preview, or --fix to apply changes.",
+        env!("CARGO_PKG_DESCRIPTION")
     )
 }
 
@@ -36,7 +35,8 @@ enum Mode {
 #[command(
     version,
     about = about(),
-    long_about = None
+    long_about = None,
+    after_help = "For more info, visit: https://github.com/maksym-arutyunyan/keepsorted"
 )]
 struct Args {
     #[arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,11 @@ struct Args {
     mode: Mode,
 
     /// Command to run for '--mode diff'
-    #[arg(long, value_name = "COMMAND", help = "Custom command for --mode diff")]
+    #[arg(
+        long,
+        value_name = "COMMAND",
+        help = "Custom command for '--mode diff'"
+    )]
     diff_command: Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ struct Args {
     #[arg(
         value_name = "PATH",
         required_unless_present = "path",
-        help = "File to process (required if --path is not used)"
+        help = "File to process (required if '--path' is not used)"
     )]
     positional_path: Option<String>,
 
@@ -72,7 +72,7 @@ struct Args {
     #[arg(
         long,
         conflicts_with_all = ["diff", "fix", "mode"],
-        help = "alias for `--mode check`",
+        help = "alias for '--mode check'",
     )]
     check: bool,
 
@@ -80,7 +80,7 @@ struct Args {
     #[arg(
         long,
         conflicts_with_all = ["check", "fix", "mode"],
-        help = "alias for `--mode diff`",
+        help = "alias for '--mode diff'",
     )]
     diff: bool,
 
@@ -88,7 +88,7 @@ struct Args {
     #[arg(
         long,
         conflicts_with_all = ["check", "diff", "mode"],
-        help = "alias for `--mode fix`",
+        help = "alias for '--mode fix'",
     )]
     fix: bool,
 
@@ -103,7 +103,7 @@ struct Args {
     )]
     mode: Mode,
 
-    /// Command to run for `--mode diff`
+    /// Command to run for '--mode diff'
     #[arg(long, value_name = "COMMAND", help = "Custom command for --mode diff")]
     diff_command: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ const EXIT_CHECK_FAILED: i32 = 4;
 
 fn about() -> String {
     format!(
-        "{}\nThis tool sorts lines in blocks marked with '# Keep sorted'. Use --mode check (or --check), --mode diff (or --diff), or --mode fix (or --fix) and enable extra features with flags. {}",
+        "{}\nSort lines inside '# Keep sorted' blocks. Use --check to verify, --diff to preview, or --fix to apply changes. {}",
         env!("CARGO_PKG_DESCRIPTION"),
         env!("CARGO_PKG_REPOSITORY")
     )
@@ -44,14 +44,14 @@ struct Args {
         long,
         value_name = "PATH",
         conflicts_with = "positional_path",
-        help = "Path to the file to run on. This option is mutually exclusive with the positional path."
+        help = "File to process (conflicts with positional path)"
     )]
     path: Option<String>,
 
     #[arg(
         value_name = "PATH",
         required_unless_present = "path",
-        help = "Path to the file to run on. This is required if the -p option is not used."
+        help = "File to process (required if --path is not used)"
     )]
     positional_path: Option<String>,
 
@@ -60,12 +60,12 @@ struct Args {
         long,
         value_name = "FEATURE",
         use_value_delimiter = true,
-        help = "Experimental feature flags. Provide a list of features to enable."
+        help = "Enable experimental features"
     )]
     features: Option<Vec<String>>,
 
     /// Recursively process directories
-    #[arg(short = 'r', long, help = "Recursively process directories")]
+    #[arg(short = 'r', long, help = "Process directories recursively")]
     recursive: bool,
 
     /// Verify that the file is already sorted
@@ -99,7 +99,7 @@ struct Args {
         value_enum,
         default_value_t = Mode::Fix,
         conflicts_with_all = ["check", "diff", "fix"],
-        help = "formatting mode: check, diff, or fix (default fix)"
+        help = "Formatting mode: check, diff, or fix"
     )]
     mode: Mode,
 
@@ -107,7 +107,7 @@ struct Args {
     #[arg(
         long,
         value_name = "COMMAND",
-        help = "command to run when the formatting mode is diff"
+        help = "Custom diff command run in diff mode"
     )]
     diff_command: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,23 +92,19 @@ struct Args {
     )]
     fix: bool,
 
-    /// Formatting mode: check, diff, or fix (default fix)
+    /// Formatting mode controlling how files are processed
     #[arg(
         short = 'm',
         long,
         value_enum,
         default_value_t = Mode::Fix,
         conflicts_with_all = ["check", "diff", "fix"],
-        help = "Formatting mode: check, diff, or fix"
+        help = "Formatting mode"
     )]
     mode: Mode,
 
-    /// Command to run to display diffs
-    #[arg(
-        long,
-        value_name = "COMMAND",
-        help = "Custom diff command run in diff mode"
-    )]
+    /// Command to run for `--mode diff`
+    #[arg(long, value_name = "COMMAND", help = "Custom command for --mode diff")]
     diff_command: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- simplify CLI help text
- update expected help output for e2e tests

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -co --exclude-standard | grep -vE "^misc/|^tests/|^e2e-tests/|^README.md" | xargs -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}`
- `./run-all.sh` *(fails: bats not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68835b1b90f4832d878daa65ee252083