### PR TITLE
test(e2e): verify diff-command output with popular tools

### DIFF
--- a/e2e-tests/diff_command_tools.bats
+++ b/e2e-tests/diff_command_tools.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+load './helpers.bash'
+
+@test "diff-command git diff --no-index" {
+  run_keepsorted --mode diff --diff-command "git diff --no-index" "e2e-tests/files/bazel/1_in.bazel"
+  [ "$status" -ne 0 ]
+  [[ "$output" == diff\ --git* ]]
+}
+
+@test "diff-command colordiff" {
+  command -v colordiff >/dev/null || skip "colordiff not installed"
+  run_keepsorted --mode diff --diff-command "colordiff -u" "e2e-tests/files/bazel/1_in.bazel"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *$'\e[0;31m'* ]]
+}
+
+@test "diff-command delta" {
+  command -v delta >/dev/null || skip "delta not installed"
+  run_keepsorted --mode diff --diff-command "delta --paging=never" "e2e-tests/files/bazel/1_in.bazel"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"│"* ]]
+}
+

--- a/e2e-tests/diff_command_tools.bats
+++ b/e2e-tests/diff_command_tools.bats
@@ -2,20 +2,20 @@
 
 load './helpers.bash'
 
-@test "diff-command git diff --no-index" {
+@test "test \`--diff-command\` with git diff --no-index" {
   run_keepsorted --mode diff --diff-command "git diff --no-index" "e2e-tests/files/bazel/1_in.bazel"
   [ "$status" -ne 0 ]
   [[ "$output" == diff\ --git* ]]
 }
 
-@test "diff-command colordiff" {
+@test "test \`--diff-command\` with colordiff" {
   command -v colordiff >/dev/null || skip "colordiff not installed"
   run_keepsorted --mode diff --diff-command "colordiff -u" "e2e-tests/files/bazel/1_in.bazel"
   [ "$status" -ne 0 ]
   [[ "$output" == *$'\e[0;31m'* ]]
 }
 
-@test "diff-command delta" {
+@test "test \`--diff-command\` with delta" {
   command -v delta >/dev/null || skip "delta not installed"
   run_keepsorted --mode diff --diff-command "delta --paging=never" "e2e-tests/files/bazel/1_in.bazel"
   [ "$status" -ne 0 ]


### PR DESCRIPTION
## Summary
- add `diff_command_tools.bats` e2e tests to run diff mode with common tools
- check output for git diff, colordiff, and delta if installed

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -co --exclude-standard | grep -vE "^misc/|^tests/|^e2e-tests/|^README.md" | xargs -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}`
- `git diff --exit-code`
- `bats e2e-tests`
- `./run-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_688361dd7968832d8d6ee53981a56a73