### PR TITLE
fix(ci): handle spaces in keepsorted script

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -140,9 +140,9 @@ jobs:
         run: |
           # Run `keepsorted` only on files that are not ignored by `.gitignore`.
           # Also ignore `./misc/` and `./tests/`.
-          git ls-files -co --exclude-standard \
-            | grep -vE "^misc/|^tests/|^e2e-tests/|^README.md" \
-            | xargs -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical"
+          git ls-files -co -z --exclude-standard \
+            | grep -vzE "^misc/|^tests/|^e2e-tests/|^README.md" \
+            | xargs -0 -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical"
         env:
           RUST_BACKTRACE: 1
 

--- a/run-all.sh
+++ b/run-all.sh
@@ -27,9 +27,9 @@ fmt_status=$?
 
 # Run `keepsorted` only on files that are not ignored by `.gitignore`.
 # Also ignore `./misc/` and `./tests/`.
-git ls-files -co --exclude-standard \
-    | grep -vE "^misc/|^tests/|^e2e-tests/|^README.md" \
-    | xargs -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}
+git ls-files -co -z --exclude-standard \
+    | grep -vzE "^misc/|^tests/|^e2e-tests/|^README.md" \
+    | xargs -0 -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}
 keepsorted_status=$?
 
 # Check if keepsorted changed any files.


### PR DESCRIPTION
## Summary
- handle filenames containing spaces when running `keepsorted`

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bats e2e-tests`
- `./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_688362399b90832d9cfd24c4c23ef815