### PR TITLE
feat(cli): parse features as enum

### DIFF
--- a/e2e-tests/files/help.txt
+++ b/e2e-tests/files/help.txt
@@ -8,7 +8,7 @@ Arguments:
 
 Options:
   -p, --path <PATH>             Path to the file to run on. This option is mutually exclusive with the positional path.
-  -f, --features <FEATURE>      Experimental feature flags. Provide a list of features to enable.
+  -f, --features <FEATURE>      Experimental feature flags. Provide a list of features to enable. [possible values: gitignore, codeowners, rust_derive_alphabetical, rust_derive_canonical]
   -r, --recursive               Recursively process directories
       --check                   alias for `--mode check`
       --diff                    alias for `--mode diff`

--- a/e2e-tests/invalid_usage.bats
+++ b/e2e-tests/invalid_usage.bats
@@ -11,3 +11,8 @@ load './helpers.bash'
   run_keepsorted -p e2e-tests/files/generic/1_in.txt e2e-tests/files/generic/1_in.txt
   [ "$status" -eq 2 ]
 }
+
+@test "test unknown feature fails" {
+  run_keepsorted --features nope e2e-tests/files/generic/1_in.txt
+  [ "$status" -eq 2 ]
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,31 @@ enum Mode {
     Fix,
 }
 
+/// Experimental features controlled via `--features`.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+#[clap(rename_all = "snake")]
+enum Feature {
+    /// Enable sorting for `.gitignore` files.
+    Gitignore,
+    /// Enable sorting for `CODEOWNERS` files.
+    Codeowners,
+    /// Alphabetical ordering for `#[derive(...)]` attributes.
+    RustDeriveAlphabetical,
+    /// Canonical ordering for `#[derive(...)]` attributes.
+    RustDeriveCanonical,
+}
+
+impl Feature {
+    fn as_str(self) -> &'static str {
+        match self {
+            Feature::Gitignore => "gitignore",
+            Feature::Codeowners => "codeowners",
+            Feature::RustDeriveAlphabetical => "rust_derive_alphabetical",
+            Feature::RustDeriveCanonical => "rust_derive_canonical",
+        }
+    }
+}
+
 #[derive(Debug, Parser)]
 #[command(
     version,
@@ -59,10 +84,11 @@ struct Args {
         short = 'f',
         long,
         value_name = "FEATURE",
+        value_enum,
         use_value_delimiter = true,
         help = "Experimental feature flags. Provide a list of features to enable."
     )]
-    features: Option<Vec<String>>,
+    features: Option<Vec<Feature>>,
 
     /// Recursively process directories
     #[arg(short = 'r', long, help = "Recursively process directories")]
@@ -163,8 +189,9 @@ fn main() {
     }
 }
 
-fn handle_file(path: &Path, features: &[String], mode: Mode, diff_command: Option<&str>) -> bool {
-    let sorted = match process_file(path, features.to_vec()) {
+fn handle_file(path: &Path, features: &[Feature], mode: Mode, diff_command: Option<&str>) -> bool {
+    let feature_names: Vec<String> = features.iter().map(|f| f.as_str().to_string()).collect();
+    let sorted = match process_file(path, feature_names) {
         Ok(s) => s,
         Err(e) => {
             eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,14 @@ impl Feature {
     }
 }
 
+use std::fmt;
+
+impl fmt::Display for Feature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Parser)]
 #[command(
     version,


### PR DESCRIPTION
## Summary
- add `Feature` enum for CLI feature flags
- use typed features in argument parser
- update help output and invalid usage tests

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -co --exclude-standard | grep -vE "^misc/|^tests/|^e2e-tests/|^README.md" | xargs -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}`
- `bats e2e-tests`
- `./run-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_6883621561c4832db609fbd4a8c9d479