### PR TITLE
fix(cli): exit with usage error on invalid features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 - Added `--mode` option with `check`, `diff`, and `fix` variants and added `--check`, `--diff`, and `--fix` convenience flags
 - Added `--diff-command` option to run a custom program when showing diffs
+- Fail with usage error if both `rust_derive` feature flags are set
 
 ## [0.1.5] - 2025-07-15
 

--- a/e2e-tests/invalid_usage.bats
+++ b/e2e-tests/invalid_usage.bats
@@ -11,3 +11,8 @@ load './helpers.bash'
   run_keepsorted -p e2e-tests/files/generic/1_in.txt e2e-tests/files/generic/1_in.txt
   [ "$status" -eq 2 ]
 }
+
+@test "test conflicting rust_derive features" {
+  run_keepsorted --features rust_derive_alphabetical,rust_derive_canonical e2e-tests/files/rust_derive/1_in.rs
+  [ "$status" -eq 2 ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,8 @@ pub fn process_file(path: &Path, features: Vec<String>) -> io::Result<String> {
     }
 
     let lines: Vec<_> = content.split_inclusive('\n').map(String::from).collect();
-    let output_lines = process_lines(classify(path, features), lines)?;
+    let strategy = classify(path, features)?;
+    let output_lines = process_lines(strategy, lines)?;
 
     let mut result = String::new();
     for (i, line) in output_lines.iter().enumerate() {
@@ -81,31 +82,36 @@ pub fn process_lines(strategy: Strategy, lines: Vec<String>) -> io::Result<Vec<S
     }
 }
 
-fn classify(path: &Path, features: Vec<String>) -> Strategy {
+fn classify(path: &Path, features: Vec<String>) -> io::Result<Strategy> {
     if is_bazel(path) {
-        return Strategy::Bazel;
+        return Ok(Strategy::Bazel);
     }
     if is_cargo_toml(path) {
-        return Strategy::CargoToml;
+        return Ok(Strategy::CargoToml);
     }
     if features.contains(&"gitignore".to_string()) && is_gitignore(path) {
-        return Strategy::Gitignore;
+        return Ok(Strategy::Gitignore);
     }
     if features.contains(&"codeowners".to_string()) && is_codeowners(path) {
-        return Strategy::Gitignore;
+        return Ok(Strategy::Gitignore);
     }
     if is_rust(path) {
         match (
             features.contains(&"rust_derive_alphabetical".to_string()),
             features.contains(&"rust_derive_canonical".to_string()),
         ) {
-            (true, true) => panic!("Mutually exclusive rust_derive feature flags are not allowed"),
-            (true, false) => return Strategy::RustDeriveAlphabetical,
-            (false, true) => return Strategy::RustDeriveCanonical,
+            (true, true) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Mutually exclusive rust_derive feature flags are not allowed",
+                ))
+            }
+            (true, false) => return Ok(Strategy::RustDeriveAlphabetical),
+            (false, true) => return Ok(Strategy::RustDeriveCanonical),
             _ => {}
         }
     }
-    Strategy::Generic
+    Ok(Strategy::Generic)
 }
 
 fn is_ignore_file(lines: &[String]) -> bool {
@@ -220,27 +226,27 @@ fn test_re_keyword_ignore_block() {
 #[test]
 fn test_classify_bazel_files() {
     assert!(matches!(
-        classify(Path::new("BUILD"), vec![]),
+        classify(Path::new("BUILD"), vec![]).unwrap(),
         Strategy::Bazel
     ));
     assert!(matches!(
-        classify(Path::new("WORKSPACE"), vec![]),
+        classify(Path::new("WORKSPACE"), vec![]).unwrap(),
         Strategy::Bazel
     ));
     assert!(matches!(
-        classify(Path::new("foo.bazel"), vec![]),
+        classify(Path::new("foo.bazel"), vec![]).unwrap(),
         Strategy::Bazel
     ));
     assert!(matches!(
-        classify(Path::new("BUILD.bazel"), vec![]),
+        classify(Path::new("BUILD.bazel"), vec![]).unwrap(),
         Strategy::Bazel
     ));
     assert!(matches!(
-        classify(Path::new("WORKSPACE.bazel"), vec![]),
+        classify(Path::new("WORKSPACE.bazel"), vec![]).unwrap(),
         Strategy::Bazel
     ));
     assert!(matches!(
-        classify(Path::new("foo.bzl"), vec![]),
+        classify(Path::new("foo.bzl"), vec![]).unwrap(),
         Strategy::Bazel
     ));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{arg, command, Parser, ValueEnum};
 use keepsorted::process_file;
+use std::io;
 use std::path::Path;
 use std::process::{self, Command};
 use walkdir::WalkDir;
@@ -167,13 +168,18 @@ fn handle_file(path: &Path, features: &[String], mode: Mode, diff_command: Optio
     let sorted = match process_file(path, features.to_vec()) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
-                "{}: failed to process file {}: {}",
-                env!("CARGO_PKG_NAME"),
-                path.display(),
-                e
-            );
-            process::exit(EXIT_RUNTIME_ERROR);
+            if e.kind() == io::ErrorKind::InvalidInput {
+                eprintln!("{}: {}", env!("CARGO_PKG_NAME"), e);
+                process::exit(EXIT_USAGE_ERROR);
+            } else {
+                eprintln!(
+                    "{}: failed to process file {}: {}",
+                    env!("CARGO_PKG_NAME"),
+                    path.display(),
+                    e
+                );
+                process::exit(EXIT_RUNTIME_ERROR);
+            }
         }
     };
 


### PR DESCRIPTION
## Summary
- return an error from `classify` when rust derive feature flags conflict
- exit with `EXIT_USAGE_ERROR` if the conflict is detected
- test conflicting feature flags in e2e suite
- note the new behavior in the changelog

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -co --exclude-standard | grep -vE "^misc/|^tests/|^e2e-tests/|^README.md" | xargs -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}`
- `git diff --exit-code`
- `bats e2e-tests`
- `./run-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_688361fe6c90832dad6eb7f14b2a2716