### PR TITLE
test: wrap CLI flag in e2e test name

### DIFF
--- a/e2e-tests/invalid_usage.bats
+++ b/e2e-tests/invalid_usage.bats
@@ -7,7 +7,7 @@ load './helpers.bash'
   [ "$status" -eq 2 ]
 }
 
-@test "test --path with positional arg fails" {
+@test "test \`--path\` with positional arg fails" {
   run_keepsorted -p e2e-tests/files/generic/1_in.txt e2e-tests/files/generic/1_in.txt
   [ "$status" -eq 2 ]
 }


### PR DESCRIPTION
## Summary
- keep e2e test naming consistent for flags

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -co -z --exclude-standard | grep -vzE "^misc/|^tests/|^e2e-tests/|^README.md" | xargs -0 -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}`
- `./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883690e6b70832db59ee1140b5b2793