### PR TITLE
fix(tests): export exit codes globally

### DIFF
--- a/e2e-tests/diff_command_tools.bats
+++ b/e2e-tests/diff_command_tools.bats
@@ -4,21 +4,21 @@ load './helpers.bash'
 
 @test "test \`--diff-command\` with git diff --no-index" {
   run_keepsorted --mode diff --diff-command "git diff --no-index" "e2e-tests/files/bazel/1_in.bazel"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq "$EXIT_SYNTAX_ERROR" ]
   [[ "$output" == diff\ --git* ]]
 }
 
 @test "test \`--diff-command\` with colordiff" {
   command -v colordiff >/dev/null || skip "colordiff not installed"
   run_keepsorted --mode diff --diff-command "colordiff -u" "e2e-tests/files/bazel/1_in.bazel"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq "$EXIT_SYNTAX_ERROR" ]
   [[ "$output" == *$'\e[0;31m'* ]]
 }
 
 @test "test \`--diff-command\` with delta" {
   command -v delta >/dev/null || skip "delta not installed"
   run_keepsorted --mode diff --diff-command "delta --paging=never" "e2e-tests/files/bazel/1_in.bazel"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq "$EXIT_SYNTAX_ERROR" ]
   [[ "$output" == *"│"* ]]
 }
 

--- a/e2e-tests/directory_error.bats
+++ b/e2e-tests/directory_error.bats
@@ -7,6 +7,6 @@ load './helpers.bash'
   cp "$FILES_DIR/generic/1_in.txt" "$TEST_TMPDIR/dir/file.txt"
 
   run_keepsorted --mode fix "$TEST_TMPDIR/dir"
-  [ "$status" -eq 2 ]
+  [ "$status" -eq "$EXIT_USAGE_ERROR" ]
 }
 

--- a/e2e-tests/features_codeowners.bats
+++ b/e2e-tests/features_codeowners.bats
@@ -8,7 +8,7 @@ load './helpers.bash'
   expected="$FILES_DIR/codeowners/CODEOWNERS_out"
 
   run_keepsorted --mode fix --features codeowners "$file"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq "$EXIT_SUCCESS" ]
   diff -u "$expected" "$file"
 }
 

--- a/e2e-tests/features_gitignore.bats
+++ b/e2e-tests/features_gitignore.bats
@@ -8,7 +8,7 @@ load './helpers.bash'
   expected="$FILES_DIR/gitignore/.gitignore_out"
 
   run_keepsorted --mode fix --features gitignore "$file"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq "$EXIT_SUCCESS" ]
   diff -u "$expected" "$file"
 }
 

--- a/e2e-tests/features_rust_derive.bats
+++ b/e2e-tests/features_rust_derive.bats
@@ -8,7 +8,7 @@ load './helpers.bash'
   expected="$FILES_DIR/rust_derive/1_out.rs"
 
   run_keepsorted --mode fix --features rust_derive_alphabetical "$file"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq "$EXIT_SUCCESS" ]
   diff -u "$expected" "$file"
 }
 
@@ -18,7 +18,7 @@ load './helpers.bash'
   expected="$FILES_DIR/rust_derive/2_out.rs"
 
   run_keepsorted --mode fix --features rust_derive_canonical "$file"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq "$EXIT_SUCCESS" ]
   diff -u "$expected" "$file"
 }
 

--- a/e2e-tests/help_flag.bats
+++ b/e2e-tests/help_flag.bats
@@ -4,6 +4,6 @@ load './helpers.bash'
 
 @test "test \`-h\` prints help" {
   run_keepsorted -h
-  [ "$status" -eq 0 ]
+  [ "$status" -eq "$EXIT_SUCCESS" ]
   diff -u "$FILES_DIR/help.txt" <(printf '%s\n' "$output")
 }

--- a/e2e-tests/helpers.bash
+++ b/e2e-tests/helpers.bash
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 FILES_DIR="$REPO_ROOT/e2e-tests/files"
 BIN="$REPO_ROOT/target/release/keepsorted"
 
 setup() {
+  source "$REPO_ROOT/utils/exit_codes.bash"
   TEST_TMPDIR="$(mktemp -d)"
 }
 

--- a/e2e-tests/invalid_usage.bats
+++ b/e2e-tests/invalid_usage.bats
@@ -4,15 +4,15 @@ load './helpers.bash'
 
 @test "test conflicting modes fail" {
   run_keepsorted --check --diff e2e-tests/files/generic/1_in.txt
-  [ "$status" -eq 2 ]
+  [ "$status" -eq "$EXIT_USAGE_ERROR" ]
 }
 
 @test "test \`--path\` with positional arg fails" {
   run_keepsorted -p e2e-tests/files/generic/1_in.txt e2e-tests/files/generic/1_in.txt
-  [ "$status" -eq 2 ]
+  [ "$status" -eq "$EXIT_USAGE_ERROR" ]
 }
 
 @test "test conflicting rust_derive features" {
   run_keepsorted --features rust_derive_alphabetical,rust_derive_canonical e2e-tests/files/rust_derive/1_in.rs
-  [ "$status" -eq 2 ]
+  [ "$status" -eq "$EXIT_USAGE_ERROR" ]
 }

--- a/e2e-tests/mode_check.bats
+++ b/e2e-tests/mode_check.bats
@@ -7,7 +7,7 @@ load './helpers.bash'
   file=$(prepare_file generic/1_in.txt)
 
   run_keepsorted --mode check "$file"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq "$EXIT_CHECK_FAILED" ]
 }
 
 @test "test \`--mode check\` succeeds on sorted file" {
@@ -15,7 +15,7 @@ load './helpers.bash'
   file=$(prepare_file generic/1_out.txt)
 
   run_keepsorted --mode check "$file"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq "$EXIT_SUCCESS" ]
 }
 
 @test "test \`--check\` shorthand" {
@@ -23,5 +23,5 @@ load './helpers.bash'
   file=$(prepare_file generic/1_in.txt)
 
   run_keepsorted --check "$file"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq "$EXIT_CHECK_FAILED" ]
 }

--- a/e2e-tests/mode_diff.bats
+++ b/e2e-tests/mode_diff.bats
@@ -4,19 +4,19 @@ load './helpers.bash'
 
 @test "test \`--mode diff\` fails on unsorted file" {
   run_keepsorted --mode diff "e2e-tests/files/bazel/1_in.bazel"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq "$EXIT_CHECK_FAILED" ]
   diff -u "$FILES_DIR/bazel/1_diff.bazel" - <<<"$output"
 }
 
 @test "test \`--diff-command\` custom command" {
   run_keepsorted --mode diff --diff-command "sh -c 'echo executed'" "e2e-tests/files/bazel/1_in.bazel"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq "$EXIT_CHECK_FAILED" ]
   diff -u "$FILES_DIR/bazel/1_diff_cmd.bazel" - <<<"$output"
 }
 
 @test "test \`--diff\` shorthand" {
   run_keepsorted --diff "e2e-tests/files/bazel/1_in.bazel"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq "$EXIT_CHECK_FAILED" ]
   diff -u "$FILES_DIR/bazel/1_diff.bazel" - <<<"$output"
 }
 

--- a/e2e-tests/mode_fix.bats
+++ b/e2e-tests/mode_fix.bats
@@ -8,7 +8,7 @@ load './helpers.bash'
   expected="$FILES_DIR/generic/1_out.txt"
 
   run_keepsorted --mode fix "$file"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq "$EXIT_SUCCESS" ]
   diff -u "$expected" "$file"
 }
 
@@ -18,7 +18,7 @@ load './helpers.bash'
   expected="$FILES_DIR/bazel/1_out.bazel"
 
   run_keepsorted --mode fix "$file"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq "$EXIT_SUCCESS" ]
   diff -u "$expected" "$file"
 }
 
@@ -28,7 +28,7 @@ load './helpers.bash'
   expected="$FILES_DIR/cargo_toml/1/Cargo_out.toml"
 
   run_keepsorted --mode fix "$file"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq "$EXIT_SUCCESS" ]
   diff -u "$expected" "$file"
 }
 
@@ -38,7 +38,7 @@ load './helpers.bash'
   expected="$FILES_DIR/bazel/1_out.bazel"
 
   run_keepsorted --fix "$file"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq "$EXIT_SUCCESS" ]
   diff -u "$expected" "$file"
 }
 

--- a/utils/exit_codes.bash
+++ b/utils/exit_codes.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Common exit codes matching README documentation
+
+declare -xgr EXIT_SUCCESS=0
+declare -xgr EXIT_SYNTAX_ERROR=1
+declare -xgr EXIT_USAGE_ERROR=2
+declare -xgr EXIT_RUNTIME_ERROR=3
+declare -xgr EXIT_CHECK_FAILED=4


### PR DESCRIPTION
## Summary
- export exit code constants with `declare -xg` so they remain visible outside of setup
- e2e helpers load these constants and tests compare status codes against the names

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -co -z --exclude-standard | grep -vzE '^misc/|^tests/|^e2e-tests/|^README.md' | xargs -0 -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}`
- `bats e2e-tests`
- `./run-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68836cf4d8a8832da6eba1610e9e7729