### PR TITLE
docs: clarify filtering in ci and scripts

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -138,11 +138,11 @@ jobs:
       - name: Run KeepSorted
         shell: bash
         run: |
-          # Run `keepsorted` only on files that are not ignored by `.gitignore`.
-          # Also ignore `./misc/` and `./tests/`.
-          git ls-files -co -z --exclude-standard \
-            | grep -vzE "^misc/|^tests/|^e2e-tests/|^README.md" \
-            | xargs -0 -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical"
+          # keepsorted works only with file paths; filter tracked files first.
+          git ls-files -z \
+            | grep -vzE '^tests/|^e2e-tests/|^README.md$' \
+            | xargs -0 -n1 ./target/release/keepsorted \
+                --features gitignore,rust_derive_canonical
         env:
           RUST_BACKTRACE: 1
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,31 @@ cargo install keepsorted
 - [Source code](https://github.com/maksym-arutyunyan/keepsorted)
 - [Issue tracker](https://github.com/maksym-arutyunyan/keepsorted/issues)
 
+## Usage
+
+- `keepsorted --check <path>` verifies sorting without modifying files.
+- `keepsorted --diff <path>` shows a diff of required changes.
+- `keepsorted --fix <path>` updates files in place.
+- Use `-r` to scan directories recursively.
+
+Run `keepsorted --check` in CI after filtering tracked files with
+`git ls-files` to prevent unsorted changes.
+
+### Pre-commit hook
+
+keepsorted only accepts explicit file paths. To scan all tracked files except
+the test directories, save this script as `.git/hooks/pre-commit`:
+
+```shell
+#!/bin/sh
+git ls-files -z \
+  | grep -vzE '^tests/|^e2e-tests/|^README.md$' \
+  | xargs -0 -n1 keepsorted --check || {
+    echo 'Run keepsorted --fix' >&2
+    exit 1
+}
+```
+
 `keepsorted` is a command-line tool that helps you sort blocks of lines in your code files.
 The tool is inspired by the Bazel build tool `buildifier`, which sorts items marked with `# Keep sorted` comments. `keepsorted` brings this functionality to any text file.
 

--- a/run-all.sh
+++ b/run-all.sh
@@ -25,11 +25,11 @@ clippy_status=$?
 cargo fmt --all -- --check
 fmt_status=$?
 
-# Run `keepsorted` only on files that are not ignored by `.gitignore`.
-# Also ignore `./misc/` and `./tests/`.
-git ls-files -co -z --exclude-standard \
-    | grep -vzE "^misc/|^tests/|^e2e-tests/|^README.md" \
-    | xargs -0 -I {} bash -c "./target/release/keepsorted '{}' --features gitignore,rust_derive_canonical" {}
+# keepsorted accepts only explicit file paths, so filter tracked files first.
+git ls-files -z \
+  | grep -vzE '^tests/|^e2e-tests/|^README.md$' \
+  | xargs -0 -n1 ./target/release/keepsorted \
+      --features gitignore,rust_derive_canonical
 keepsorted_status=$?
 
 # Check if keepsorted changed any files.


### PR DESCRIPTION
## Summary
- explain how to filter tracked files in README usage
- update pre-commit example with grep and xargs
- use same pattern in workflow and run-all script

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `./run-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_688386257590832d98a40283fae116e0