### PR TITLE
fix(cli): exit diff check appropriately

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ use std::process::{self, Command};
 ///
 /// clap also exits with this code on usage errors such as conflicting flags.
 const EXIT_USAGE_ERROR: i32 = 2;
+/// Exit code used for syntax errors in the input.
+const EXIT_SYNTAX_ERROR: i32 = 1;
 /// Exit code used for I/O problems or internal bugs.
 const EXIT_RUNTIME_ERROR: i32 = 3;
 /// Exit code used when `--mode check` or `--mode diff` detects unsorted files.
@@ -270,7 +272,11 @@ fn handle_file(path: &Path, features: &[Feature], mode: Mode, diff_command: Opti
                         Ok(out) => {
                             print!("{}", String::from_utf8_lossy(&out.stdout));
                             if !out.status.success() {
-                                process::exit(out.status.code().unwrap_or(EXIT_RUNTIME_ERROR));
+                                let code = out.status.code().unwrap_or(EXIT_RUNTIME_ERROR);
+                                if code == 1 {
+                                    process::exit(EXIT_SYNTAX_ERROR);
+                                }
+                                process::exit(code);
                             }
                         }
                         Err(e) => {


### PR DESCRIPTION
## Summary
- add missing `EXIT_SYNTAX_ERROR` exit code constant
- propagate syntax error exit when custom diff command reports differences

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `bats e2e-tests`
- `./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_688397eeb6cc832dab1d44cec8d25254