### PR TITLE
docs(readme): drop recursive flag mention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Documentation
 - Document installation command and provide docs.rs, source code, and issue tracker links near the top of README
+- Remove mention of deprecated `-r` flag from README
 
 ## [0.1.5] - 2025-07-15
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ cargo install keepsorted
 - `keepsorted --check <path>` verifies sorting without modifying files.
 - `keepsorted --diff <path>` shows a diff of required changes.
 - `keepsorted --fix <path>` updates files in place.
-- Use `-r` to scan directories recursively.
 
 Run `keepsorted --check` in CI after filtering tracked files with
 `git ls-files` to prevent unsorted changes.


### PR DESCRIPTION
## Summary
- remove outdated -r flag from README
- note documentation change in changelog

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `bats e2e-tests`
- `./run-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_688397d4f8d8832db08f0a35a391f45c