### PR TITLE
docs: clarify ignore directives and single-file usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Documentation
 - Document installation command and provide docs.rs, source code, and issue tracker links near the top of README
+- Explain `# keepsorted: ignore file` and `# keepsorted: ignore block` directives and clarify that directory traversal should be handled externally
 
 ## [0.1.5] - 2025-07-15
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cargo install keepsorted
 - `keepsorted --check <path>` verifies sorting without modifying files.
 - `keepsorted --diff <path>` shows a diff of required changes.
 - `keepsorted --fix <path>` updates files in place.
-- Use `-r` to scan directories recursively.
+- keepsorted only processes a single file at a time. Directory traversal and filtering are left to shell tools like `git ls-files` so that you can easily include or exclude paths. See [Architecture](docs/architecture.md) for details.
 
 Run `keepsorted --check` in CI after filtering tracked files with
 `git ls-files` to prevent unsorted changes.
@@ -184,11 +184,11 @@ Use `--diff-command <command>` to delegate diff generation to an external progra
 Use `--mode fix` (or `--fix`) to rewrite the file in place.
 
 The command exits with these codes:
-1. `0` — success
-2. `1` — syntax errors in input
-3. `2` — usage errors: invoked incorrectly
-4. `3` — unexpected runtime errors
-5. `4` — check mode failed (reformat is needed)
+- `0` — success
+- `1` — syntax errors in input
+- `2` — usage errors: invoked incorrectly
+- `3` — unexpected runtime errors
+- `4` — check mode failed (reformat is needed)
 
 ```shell
 $ keepsorted --check Cargo.toml

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,11 +7,11 @@ This document explains how the main pieces of the `keepsorted` crate fit togethe
 `keepsorted` was inspired by [Buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier), which sorts items in Bazel `BUILD` files. The command-line flags and exit codes follow a similar design so that tooling can integrate either tool with minimal changes.
 
 The CLI returns these codes:
-1. `0` — success
-2. `1` — syntax errors in input
-3. `2` — incorrect command usage
-4. `3` — unexpected runtime failures
-5. `4` — check mode detected unsorted files
+- `0` — success
+- `1` — syntax errors in input
+- `2` — incorrect command usage
+- `3` — unexpected runtime failures
+- `4` — check mode detected unsorted files
 
 ## Sorting Behaviour
 
@@ -20,6 +20,10 @@ The core feature is sorting lines while preserving any comments associated with 
 Some experimental features exist:
 - **Rust derive sorting** temporarily supports alphabetical or canonical ordering of `#[derive(...)]` attributes because `cargo fmt` does not yet implement this. The functionality is intentionally basic and may be removed once rustfmt provides a stable implementation.
 - **Gitignore and CODEOWNERS sorting** helps maintain consistent ordering but should be used carefully since pattern order can affect semantics.
+
+Sorting can be skipped with two special directives:
+- **`# keepsorted: ignore file`** anywhere in a file leaves the entire file unchanged.
+- **`# keepsorted: ignore block`** inside a `# Keep sorted` block preserves that block without reordering.
 
 ## Modules
 
@@ -35,7 +39,9 @@ Each file under `src/strategies/` provides a `process` function that sorts lines
 
 ### CLI (`src/main.rs`)
 
-`main.rs` implements the command-line interface using `clap`. It parses arguments, selects the formatting mode (check, diff or fix) and passes a single file to `handle_file`. Directory traversal is intentionally left to external scripts so that the binary stays simple and composable. The helper `handle_file` runs the crate API on each file and applies the chosen mode.
+`main.rs` implements the command-line interface using `clap`. It parses arguments, selects the formatting mode (check, diff or fix) and passes a single file to `handle_file`. Directory traversal is intentionally left to external scripts so that the binary stays simple and composable. There is deliberately no `-r` or `--recursive` option; use tools like `git ls-files` if you need to process multiple files. The helper `handle_file` runs the crate API on each file and applies the chosen mode.
+
+keepsorted focuses on sorting and does not try to walk directories itself. Implementing a fully featured crawler would require handling ignore files, generated sources and other project-specific rules. Existing tools already solve these problems, so the CLI expects callers to provide an explicit list of files. This design keeps the binary small while letting users combine it with powerful shell filters.
 
 ### Crate API (`src/lib.rs`)
 


### PR DESCRIPTION
## Summary
- document ignore directives in the architecture guide
- explain why the CLI only accepts explicit file paths
- remove numbered lists for exit codes

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `bats e2e-tests`
- `./run-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_688398e44b50832db70bea627b23a1f6