### PR TITLE
docs: clarify sorting behaviour

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,8 @@ The CLI returns these codes:
 
 The core feature is sorting lines while preserving any comments associated with each item. Multi-line items (for example in `Cargo.toml`) are kept intact when possible so that sections remain readable.
 
+Comments are gathered until a non-comment line appears. Lines beginning with `#`, `//` or `--` are treated as comments for this purpose. The collected lines are attached to the next sortable item. When the block ends, any remaining trailing comments are appended at the end. This mirrors the behaviour in `src/strategies/generic.rs`, where each comment group is stored separately from its code line and reinserted after sorting. As a result, remarks or `TODO` notes stay with the relevant entry even after reordering.
+
 Sorting can be skipped with two special directives:
 - **`# keepsorted: ignore file`** anywhere in a file leaves the entire file unchanged.
 - **`# keepsorted: ignore block`** inside a `# Keep sorted` block preserves that block without reordering.


### PR DESCRIPTION
## Summary
- document how comments are associated with items when sorting

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883a3a969c8832daebee936e02ca3f7