### PR TITLE
docs: clarify testing strategy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,9 +73,9 @@ Both functions rely on private helpers such as `classify` for strategy selection
 
 End-to-end tests in `e2e-tests` invoke the CLI using a command-line test framework to simulate real usage. Each flag or parameter has its own test file with descriptive names following the Arrange–Act–Assert style. This keeps tests short and focused while covering many combinations.
 
-Tests use real input files and golden outputs. Each test case includes input.txt and expected.txt stored in the same subdirectory for clarity and simplicity.
+Tests use real input files and golden outputs. Each test case includes `input.txt` and `expected.txt` stored in the same subdirectory for clarity and simplicity. Shared exit codes live in `utils/exit_codes.bash` so that the CLI and tests use the same constants.
 
-Rust unit tests inside `tests/` verify the behaviour of individual strategies for different file and data types.
+Rust unit tests inside `tests/` verify the behaviour of individual strategies for different file and data types. The `run-all.sh` script runs the full validation sequence and should be executed before committing changes.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary
- document shared exit codes and validation script

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `bats e2e-tests`
- `./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883a3d68884832d8c3822f71c432505