### PR TITLE
docs(architecture): expand experimental features section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Document installation command and provide docs.rs, source code, and issue tracker links near the top of README
 - Remove mention of deprecated `-r` flag from README
 - Explain `# keepsorted: ignore file` and `# keepsorted: ignore block` directives and clarify that directory traversal should be handled externally
+- Expand Experimental Features section with an example of enabling multiple flags
 
 ## [0.1.5] - 2025-07-15
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,13 @@ Some experimental features exist:
 
 ## Experimental Features
 
-The following features are behind flags and must be enabled explicitly using `--features`:
+Several optional features are still evolving and therefore are **disabled by default**. You can opt into them with the `--features` command-line flag or by enabling the corresponding crate features. Features are comma‑separated so you may combine multiple behaviours at once:
+
+```shell
+$ keepsorted <path> --features gitignore,codeowners
+```
+
+Available experimental flags:
 
 - `rust_derive_alphabetical` — sorts `#[derive(...)]` attributes alphabetically
 - `rust_derive_canonical` — sorts `#[derive(...)]` attributes in canonical Rust order


### PR DESCRIPTION
## Summary
- document experimental features in more detail
- show how to enable multiple flags at once

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883a3c82504832d87280ad6dad97b77