### PR TITLE
docs: clarify Cargo.toml multiline sorting

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,9 @@ Each file under `src/strategies/` provides a `process` function that sorts lines
 - **`generic.rs`** – handles text blocks marked with `# Keep sorted`.
 - **`bazel.rs`** – sorts lists in Bazel `BUILD`/`.bzl` files.
 - **`cargo_toml.rs`** – sorts dependency tables in `Cargo.toml` files.
+  The strategy tracks multi-line sections and only sorts once the block
+  closes using helpers such as `is_multi_line_code` and
+  `is_code_section_completed`.
 - **`gitignore.rs`** – sorts `.gitignore` or `CODEOWNERS` files when the feature is enabled.
 - **`rust_derive.rs`** – reorders `#[derive(...)]` attributes; may also trigger a generic sort.
 


### PR DESCRIPTION
## Summary
- document that Cargo.toml sorting waits for multiline sections to close
- mention helper functions `is_multi_line_code` and `is_code_section_completed`

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883a3b957c0832dbcc79ece867788dd