### PR TITLE
docs(readme): rewrite and document features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Remove mention of deprecated `-r` flag from README
 - Explain `# keepsorted: ignore file` and `# keepsorted: ignore block` directives and clarify that directory traversal should be handled externally
 - Expand Experimental Features section with an example of enabling multiple flags
+- Rewrite README for clarity and document crate API, experimental features, and limitations
 
 ## [0.1.5] - 2025-07-15
 

--- a/README.md
+++ b/README.md
@@ -1,39 +1,38 @@
 # keepsorted
 
-[gh-image]: https://github.com/maksym-arutyunyan/keepsorted/workflows/CI/badge.svg
-[gh-checks]: https://github.com/maksym-arutyunyan/keepsorted/actions/workflows/workflow.yaml
-[cratesio-image]: https://img.shields.io/crates/v/keepsorted.svg
-[cratesio]: https://crates.io/crates/keepsorted
-[docsrs-image]: https://docs.rs/keepsorted/badge.svg
-[docsrs]: https://docs.rs/keepsorted
+[![CI](https://github.com/maksym-arutyunyan/keepsorted/workflows/CI/badge.svg)](https://github.com/maksym-arutyunyan/keepsorted/actions/workflows/workflow.yaml)
+[![crates.io](https://img.shields.io/crates/v/keepsorted.svg)](https://crates.io/crates/keepsorted)
+[![docs.rs](https://docs.rs/keepsorted/badge.svg)](https://docs.rs/keepsorted)
 
-[![keepsorted GitHub Actions][gh-image]][gh-checks]
-[![keepsorted on crates.io][cratesio-image]][cratesio]
-[![keepsorted on docs.rs][docsrs-image]][docsrs]
+**keepsorted** sorts selected blocks of text in code files while keeping comments in place. It works on many file types, such as `Cargo.toml`, Bazel files and general text.  
+See [Architecture](docs/architecture.md) for a deeper explanation.
 
 ```shell
 cargo install keepsorted
 ```
 
 - [Documentation](https://docs.rs/keepsorted)
-- [Source code](https://github.com/maksym-arutyunyan/keepsorted)
-- [Issue tracker](https://github.com/maksym-arutyunyan/keepsorted/issues)
-- [Architecture](docs/architecture.md)
+- [Source](https://github.com/maksym-arutyunyan/keepsorted)
+- [Issues](https://github.com/maksym-arutyunyan/keepsorted/issues)
 
-## Usage
+## Quick Start
 
-- `keepsorted --check <path>` verifies sorting without modifying files.
-- `keepsorted --diff <path>` shows a diff of required changes.
-- `keepsorted --fix <path>` updates files in place.
-- keepsorted only processes a single file at a time. Directory traversal and filtering are left to shell tools like `git ls-files` so that you can easily include or exclude paths. See [Architecture](docs/architecture.md) for details.
+Run `keepsorted` on a single file:
 
-Run `keepsorted --check` in CI after filtering tracked files with
-`git ls-files` to prevent unsorted changes.
+```shell
+# verify sorting without editing
+keepsorted --check <path>
 
-### Pre-commit hook
+# show differences
+keepsorted --diff <path>
 
-keepsorted only accepts explicit file paths. To scan all tracked files except
-the test directories, save this script as `.git/hooks/pre-commit`:
+# apply changes in place (default)
+keepsorted --fix <path>
+```
+
+The tool accepts one explicit file path at a time. Use shell commands like `git ls-files` or `find` to generate a list of files for CI or pre-commit hooks.
+
+### Pre-commit Example
 
 ```shell
 #!/bin/sh
@@ -45,154 +44,48 @@ git ls-files -z \
 }
 ```
 
-`keepsorted` is a command-line tool that helps you sort blocks of lines in your code files.
-The tool is inspired by the Bazel build tool `buildifier`, which sorts items marked with `# Keep sorted` comments. `keepsorted` brings this functionality to any text file.
+## Using as a Library
 
-It works by sorting lines within a block that starts with the activation comment `# Keep sorted`.
-In some files, like `Cargo.toml`, it sorts automatically without needing an activation comment.
+`keepsorted` can be embedded in Rust projects. Two main functions are provided:
 
-The tool can also recognize comments attached to non-comment lines, like this:
+```rust
+use keepsorted::{process_lines, Strategy};
+use std::io;
 
-```py
-# Before:
-dependencies = [
-    # Keep sorted.
-    'ddd',
-    'ccc',
-    # TODO: remove this dependency.
-    'bbb',
-    'aaa',
-]
+fn main() -> io::Result<()> {
+    // Sort an in-memory list of lines
+    let lines = vec!["# Keep sorted".into(), "b".into(), "a".into()];
+    let sorted = process_lines(Strategy::Generic, lines)?;
 
-# After:
-dependencies = [
-    # Keep sorted.
-    'aaa',
-    # TODO: remove this dependency.
-    'bbb',
-    'ccc',
-    'ddd',
-]
+    Ok(())
+}
 ```
 
-You can see more examples in the `./e2e-tests/files/` directory.
+See [Architecture](docs/architecture.md#crate-api-srclibrs) for more details.
 
-## Keywords
+## Experimental Features
 
-Comments can begin with `#`, `//`, or `--`. The following examples use `#`.
-
-- `# Keep sorted` or `# keepsorted: keep sorted` sorts the next block of lines
-- `# keepsorted: ignore file` anywhere in the file skips sorting
-- `# keepsorted: ignore block` within a block skips sorting that block
-
-## Supported Files
-
-### Generic Text Files
-
-For generic text files, the tool sorts blocks that start with `# Keep sorted` and end with a newline.
-
-```txt
-# Names
-# Keep sorted
-Alice
-Bob
-Conrad
-
-# Colors
-# Keep sorted
-Blue
-Green
-Red
-```
-
-### Bazel
-
-In Bazel files, keepsorted sorts lines within `[...]` blocks that start with `# Keep sorted`.
-
-```bazel
-DEPENDENCIES = [
-    # Keep sorted
-    "a",
-    "b",
-]
-```
-
-### Cargo.toml
-
-In `Cargo.toml` files, the tool sorts lines within blocks that start with `[dependencies]`, `[dev-dependencies]`, etc., and end with an empty line.
-
-```toml
-[dependencies]
-a = "0.1.0"
-b = { workspace = true }
-
-# keepsorted: ignore block
-[dev-dependencies]
-y = { workspace = true }
-x = "0.3.0"
-```
-
-### .gitignore & CODEOWNERS
-
-*NOTE: These features are experimental and require feature flags.*
+Several optional behaviours are disabled by default. Enable them with the comma-separated `--features` flag:
 
 ```shell
-$ keepsorted <path> --features gitignore,codeowners
+keepsorted <path> --features gitignore,codeowners
 ```
 
-In `.gitignore` and `CODEOWNERS` files, the tool sorts blocks separated by empty lines while keeping comments in place, except for the opening block comment.
+Available flags:
 
-**(!) IMPORTANT**: the order of patterns can be important because it gets executed from top to bottom from more generic to more specific rules, therefore use this feature with extra care.
+- `gitignore` – sort `.gitignore` and `CODEOWNERS`
+- `codeowners` – sort `CODEOWNERS` when combined with `gitignore`
+- `rust_derive_alphabetical` – alphabetize `#[derive(...)]`
+- `rust_derive_canonical` – canonical order of `#[derive(...)]`
 
-```.gitignore
-# Various build artifacts
-**/build
-**/build-out
-**/build-tmp
-artifacts
+## Limitations
 
-# Bazel outdir dirs
-# keepsorted: ignore block
-bazel-c.pb
-user.bazelrc
-bazel-b.txt
-/bazel-*
-bazel-a.txt
-```
+`keepsorted` intentionally does not:
 
-### Rust Derive
+- Walk directories recursively (use tools like `find` or `git ls-files`)
+- Parse every file type in depth
+- Respect ignore files automatically
+- Detect project configuration files or layout
+- Replace formatters such as `rustfmt` or `prettier`
 
-*NOTE: These features are experimental and require feature flags.*
-
-```shell
-$ keepsorted <path> --features rust_derive_alphabetical
-# or
-$ keepsorted <path> --features rust_derive_canonical
-```
-
-The feature is inspired by a closed ticket to update rust style, [link](https://github.com/rust-lang/style-team/issues/154).
-
-### Formatting mode
-
-The `--mode` option controls whether the file is modified. It accepts `check`,
-`diff`, or `fix` (the default). The flags `--check`, `--diff`, and `--fix` are
-aliases for `--mode check`, `--mode diff`, and `--mode fix` respectively.
-
-Use `--mode check` (or `--check`) to verify that a file is already sorted without modifying it.
-Use `--mode diff` (or `--diff`) to print a unified diff of the required changes.
-Use `--diff-command <command>` to delegate diff generation to an external program.
-Use `--mode fix` (or `--fix`) to rewrite the file in place.
-
-The command exits with these codes:
-- `0` — success
-- `1` — syntax errors in input
-- `2` — usage errors: invoked incorrectly
-- `3` — unexpected runtime errors
-- `4` — check mode failed (reformat is needed)
-
-```shell
-$ keepsorted --check Cargo.toml
-$ keepsorted --diff Cargo.toml
-$ keepsorted --fix Cargo.toml
-```
-
+Refer to [Architecture – Out of Scope](docs/architecture.md#out-of-scope) for the full list.


### PR DESCRIPTION
## Summary
- rewrite README for clarity and brevity
- document crate API usage and experimental features
- outline project limitations
- note README rewrite in changelog

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `./run-all.sh` *(fails: `bats` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a627c274832da55a0ec0fe4a9ac1