### PR TITLE
docs(cli): expand long help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Remove mention of deprecated `-r` flag from README
 - Explain `# keepsorted: ignore file` and `# keepsorted: ignore block` directives and clarify that directory traversal should be handled externally
 - Expand Experimental Features section with an example of enabling multiple flags
+- Clarify CLI help text with skip keywords, comment types and exit codes
 
 ## [0.1.5] - 2025-07-15
 

--- a/e2e-tests/files/help.txt
+++ b/e2e-tests/files/help.txt
@@ -1,5 +1,4 @@
 A tool for sorting blocks of lines in code files
-Sort lines inside '# Keep sorted' blocks. Use --check to verify, --diff to preview, or --fix to apply changes.
 
 Usage: keepsorted [OPTIONS] [PATH]
 

--- a/e2e-tests/files/help_long.txt
+++ b/e2e-tests/files/help_long.txt
@@ -1,0 +1,58 @@
+A tool for sorting blocks of lines in code files.
+Sort lists inside '# Keep sorted' blocks. Generic and Bazel files require the comment. Cargo.toml, .gitignore and CODEOWNERS are sorted automatically. Skip sorting with '# keepsorted: ignore file' or '# keepsorted: ignore block'. Comments starting with '#', '//' or '--' are preserved.
+
+Return codes:
+0: success, everything went well
+1: syntax errors in input
+2: usage errors: invoked incorrectly
+3: unexpected runtime errors: file I/O problems or internal bugs
+4: check mode failed (reformat is needed)
+
+Usage: keepsorted [OPTIONS] [PATH]
+
+Arguments:
+  [PATH]
+          File to process (required if '--path' is not used)
+
+Options:
+  -p, --path <PATH>
+          File to process (conflicts with positional path)
+
+  -f, --features <FEATURE>
+          Enable experimental features
+
+          Possible values:
+          - gitignore:                Enable sorting for `.gitignore` files
+          - codeowners:               Enable sorting for `CODEOWNERS` files
+          - rust_derive_alphabetical: Alphabetical ordering for `#[derive(...)]` attributes
+          - rust_derive_canonical:    Canonical ordering for `#[derive(...)]` attributes
+
+      --check
+          alias for '--mode check'
+
+      --diff
+          alias for '--mode diff'
+
+      --fix
+          alias for '--mode fix'
+
+  -m, --mode <MODE>
+          Formatting mode
+          
+          [default: fix]
+
+          Possible values:
+          - check: Verify that the file is already sorted
+          - diff:  Print a diff of the required changes
+          - fix:   Rewrite the file with sorted content
+
+      --diff-command <COMMAND>
+          Custom command for '--mode diff'
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+For more info, visit: https://github.com/maksym-arutyunyan/keepsorted

--- a/e2e-tests/help_long_flag.bats
+++ b/e2e-tests/help_long_flag.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+load './helpers.bash'
+
+@test "test \`--help\` prints long help" {
+  run_keepsorted --help
+  [ "$status" -eq "$EXIT_SUCCESS" ]
+  diff -u "$FILES_DIR/help_long.txt" <(printf '%s\n' "$output")
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,10 +16,27 @@ const EXIT_RUNTIME_ERROR: i32 = 3;
 const EXIT_CHECK_FAILED: i32 = 4;
 
 fn about() -> String {
-    format!(
-        "{}\nSort lines inside '# Keep sorted' blocks. Use --check to verify, --diff to preview, or --fix to apply changes.",
-        env!("CARGO_PKG_DESCRIPTION")
-    )
+    env!("CARGO_PKG_DESCRIPTION").to_string()
+}
+
+fn long_about() -> String {
+    "A tool for sorting blocks of lines in code files.\n\
+Sort lists inside '# Keep sorted' blocks. Generic and Bazel files require the comment. \
+Cargo.toml, .gitignore and CODEOWNERS are sorted automatically. \
+Skip sorting with '# keepsorted: ignore file' or '# keepsorted: ignore block'. \
+Comments starting with '#', '//' or '--' are preserved.\n\
+\n\
+Return codes:\n\
+  0: success, everything went well\n\
+  1: syntax errors in input\n\
+  2: usage errors: invoked incorrectly\n\
+  3: unexpected runtime errors: file I/O problems or internal bugs\n\
+  4: check mode failed (reformat is needed)"
+        .to_string()
+}
+
+fn after_help() -> &'static str {
+    "For more info, visit: https://github.com/maksym-arutyunyan/keepsorted"
 }
 
 /// Formatting mode controlling whether the file is overwritten or only verified.
@@ -70,8 +87,8 @@ impl fmt::Display for Feature {
 #[command(
     version,
     about = about(),
-    long_about = None,
-    after_help = "For more info, visit: https://github.com/maksym-arutyunyan/keepsorted"
+    long_about = long_about(),
+    after_help = after_help()
 )]
 struct Args {
     #[arg(


### PR DESCRIPTION
## Summary
- explain when `# Keep sorted` comment is required
- document skip keywords and comment types
- show return codes in a small table

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `bats e2e-tests`
- `./run-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_6883abc9ae80832d85bcceaa56e01788