### PR TITLE
docs: rename architecture doc to specs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -24,6 +24,6 @@
 - Always format code using `cargo fmt`.
 - Address warnings reported by `cargo clippy` as invoked in `run-all.sh`.
 - Keep entries in `Cargo.toml` and other marked blocks sorted using `keepsorted` comments.
-- Ensure code changes adhere to `docs/architecture.md`, which is the source of truth. Modify this file only when explicitly instructed by a human.
+- Ensure code changes adhere to `docs/specs.md`, which is the source of truth. Modify this file only when explicitly instructed by a human.
 - Update `CHANGELOG.md` for user‑visible changes following the Keep a Changelog format.
 - Commit messages should also follow the Conventional Commits style.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cargo install keepsorted
 - [Documentation](https://docs.rs/keepsorted)
 - [Source code](https://github.com/maksym-arutyunyan/keepsorted)
 - [Issue tracker](https://github.com/maksym-arutyunyan/keepsorted/issues)
-- [Architecture](docs/architecture.md)
+- [Specs](docs/specs.md)
 
 ## Overview
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -1,6 +1,6 @@
-# Architecture
+# Specification
 
-This document explains how the main pieces of the `keepsorted` crate fit together.
+This specification describes how the `keepsorted` application is expected to behave and outlines its current design. It acts as the source of truth for future code changes.
 
 ## Inspiration
 


### PR DESCRIPTION
## Summary
- rename `docs/architecture.md` to `docs/specs.md`
- reference `docs/specs.md` as the source of truth
- update README link

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6884527037a4832da1424e1411b96cc4