### PR TITLE
feat(cli): skip binary files in recursive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+- Skip binary files during recursive traversal
+
 ## [0.1.6] - 2025-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ keepsorted --fix <path>     # rewrite files in place (default)
 ```
 
 Use `--recursive` (`-r`) to process directories. Combine with `git ls-files` in
-CI to check only tracked files.
+CI to check only tracked files. Binary files are skipped automatically.
 
 ### Keywords
 

--- a/e2e-tests/recursive_skip_binary.bats
+++ b/e2e-tests/recursive_skip_binary.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+load './helpers.bash'
+
+@test "recursive skips binary files" {
+  mkdir "$TEST_TMPDIR/dir"
+  cp "$FILES_DIR/generic/1_in.txt" "$TEST_TMPDIR/dir/file.txt"
+  printf '\x00\xff\x00\xff' > "$TEST_TMPDIR/dir/binary.bin"
+
+  run_keepsorted --mode fix --recursive "$TEST_TMPDIR/dir"
+  [ "$status" -eq "$EXIT_SUCCESS" ]
+  diff "$FILES_DIR/generic/1_out.txt" "$TEST_TMPDIR/dir/file.txt"
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,23 @@ fn main() {
 }
 
 fn handle_file(path: &Path, features: &[Feature], mode: Mode, diff_command: Option<&str>) -> bool {
+    match is_text_file(path) {
+        Ok(true) => {}
+        Ok(false) => {
+            eprintln!("skipping binary file {}", path.display());
+            return true;
+        }
+        Err(e) => {
+            eprintln!(
+                "{}: failed to read file {}: {}",
+                env!("CARGO_PKG_NAME"),
+                path.display(),
+                e
+            );
+            process::exit(EXIT_RUNTIME_ERROR);
+        }
+    }
+
     let feature_names: Vec<String> = features.iter().map(|f| f.as_str().to_string()).collect();
     let sorted = match process_file(path, feature_names) {
         Ok(s) => s,
@@ -368,4 +385,18 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+fn is_text_file(path: &Path) -> io::Result<bool> {
+    use std::fs::File;
+    use std::io::Read;
+
+    let mut file = File::open(path)?;
+    let mut buf = [0u8; 8192];
+    let n = file.read(&mut buf)?;
+    let slice = &buf[..n];
+    if slice.contains(&0) {
+        return Ok(false);
+    }
+    Ok(std::str::from_utf8(slice).is_ok())
 }


### PR DESCRIPTION
## Summary
- detect binary files with `is_text_file`
- ignore binary files when processing recursively
- document binary file skipping
- test recursive traversal with binary files

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `bats e2e-tests`
- `./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68848755a150832dbdf73db4f06054de