### PR TITLE
feat(cli): add quiet flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ format and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 - Skip binary files during recursive traversal
+- `--quiet` flag to suppress informational output
 
 ## [0.1.6] - 2025-07-26
 

--- a/e2e-tests/files/generic/1_diff.txt
+++ b/e2e-tests/files/generic/1_diff.txt
@@ -1,0 +1,11 @@
+--- a/e2e-tests/files/generic/1_in.txt
++++ b/e2e-tests/files/generic/1_in.txt
+@@ -1,4 +1,4 @@
+ # Expect block without trailing empty line at EOF to be sorted.
+ # Keep sorted.
+-b
+-a
+\ No newline at end of file
++a
++b
+\ No newline at end of file

--- a/e2e-tests/files/help.txt
+++ b/e2e-tests/files/help.txt
@@ -9,6 +9,7 @@ Options:
   -p, --path <PATH>             File to process (conflicts with positional path)
   -r, --recursive               Process directories recursively
   -f, --features <FEATURE>      Enable experimental features [possible values: gitignore, codeowners, rust_derive_alphabetical, rust_derive_canonical]
+  -q, --quiet                   Silence non-error messages
       --check                   alias for '--mode check'
       --diff                    alias for '--mode diff'
       --fix                     alias for '--mode fix'

--- a/e2e-tests/files/help_long.txt
+++ b/e2e-tests/files/help_long.txt
@@ -31,6 +31,9 @@ Options:
           - rust_derive_alphabetical: Alphabetical ordering for `#[derive(...)]` attributes
           - rust_derive_canonical:    Canonical ordering for `#[derive(...)]` attributes
 
+  -q, --quiet
+          Silence non-error messages
+
       --check
           alias for '--mode check'
 

--- a/e2e-tests/quiet_flag.bats
+++ b/e2e-tests/quiet_flag.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load './helpers.bash'
+
+@test "--quiet suppresses skip messages" {
+  mkdir "$TEST_TMPDIR/dir"
+  cp "$FILES_DIR/generic/1_in.txt" "$TEST_TMPDIR/dir/file.txt"
+  printf '\x00' > "$TEST_TMPDIR/dir/binary.bin"
+
+  run_keepsorted --mode diff --recursive --quiet "$TEST_TMPDIR/dir"
+  [ "$status" -eq "$EXIT_CHECK_FAILED" ]
+  [[ "$output" == ---* ]]
+  [[ "$output" == *"@@ -1,4 +1,4 @@"* ]]
+  [[ "$stderr" == "" ]]
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,10 @@ struct Args {
     )]
     features: Option<Vec<Feature>>,
 
+    /// Suppress informational output
+    #[arg(short = 'q', long, help = "Silence non-error messages")]
+    quiet: bool,
+
     /// Verify that the file is already sorted
     #[arg(
         long,
@@ -213,11 +217,23 @@ fn main() {
             process::exit(EXIT_RUNTIME_ERROR);
         }
         for file in files {
-            if !handle_file(&file, &features, mode, args.diff_command.as_deref()) {
+            if !handle_file(
+                &file,
+                &features,
+                mode,
+                args.diff_command.as_deref(),
+                args.quiet,
+            ) {
                 exit_code = EXIT_CHECK_FAILED;
             }
         }
-    } else if !handle_file(path, &features, mode, args.diff_command.as_deref()) {
+    } else if !handle_file(
+        path,
+        &features,
+        mode,
+        args.diff_command.as_deref(),
+        args.quiet,
+    ) {
         exit_code = EXIT_CHECK_FAILED;
     }
 
@@ -226,11 +242,19 @@ fn main() {
     }
 }
 
-fn handle_file(path: &Path, features: &[Feature], mode: Mode, diff_command: Option<&str>) -> bool {
+fn handle_file(
+    path: &Path,
+    features: &[Feature],
+    mode: Mode,
+    diff_command: Option<&str>,
+    quiet: bool,
+) -> bool {
     match is_text_file(path) {
         Ok(true) => {}
         Ok(false) => {
-            eprintln!("skipping binary file {}", path.display());
+            if !quiet {
+                eprintln!("skipping binary file {}", path.display());
+            }
             return true;
         }
         Err(e) => {


### PR DESCRIPTION
## Summary
- add `--quiet` option to hide non-error messages like skipped files
- test quiet mode and update help docs

## Testing
- `cargo build --release --all-targets`
- `cargo test`
- `cargo test --release`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1 ./target/release/keepsorted --features gitignore,rust_derive_canonical`
- `bats e2e-tests`
- `./run-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68848bf8f734832d91ac6f9959673299