### PR TITLE
docs(meta): clarify specs and workflow

### DIFF
--- a/meta/AGENTS.md
+++ b/meta/AGENTS.md
@@ -3,13 +3,16 @@
 keepsorted is a Rust tool that sorts annotated lists while preserving nearby comments. It helps keep configuration files and code blocks tidy.
 
 ## Behaviors
+
 - Follow Conventional Commits for commit messages and PR titles.
 - For Rust or manifest changes, run each command in `verify.sh` and then the script itself. Doc-only changes may skip these checks.
 - Use the Rust version pinned in `rust-toolchain.toml`.
 - Keep lists and manifest sections sorted and update `CHANGELOG.md` for user-facing changes.
 - Do not modify `docs/specs.md` unless a human requests it.
+- Format Markdown with `mdformat`; CI runs a check to ensure files stay formatted.
 
 ## Reference
+
 | File | Purpose |
 | ---- | ------- |
 | `SPECS.md` | Product scope and problem definition. |
@@ -17,6 +20,7 @@ keepsorted is a Rust tool that sorts annotated lists while preserving nearby com
 | `WORKFLOW.md` | Development workflow, checks, and release process. |
 
 ## Conventions
-- Markdown files use `#`-style headings and wrap text reasonably.
+
+- Markdown files use `#`-style headings, wrap text reasonably, and rely on `mdformat` for consistent style.
 - File names and commit scopes use `snake_case` and lowercase.
 - Paths and examples assume the repository root unless noted.

--- a/meta/SPECS.md
+++ b/meta/SPECS.md
@@ -1,17 +1,21 @@
 # SPECS
 
+Defines the expected behavior of `keepsorted`.
+
 ## Problem
+
 Unsorted lists in source and config files are tedious to maintain and can detach comments from the items they describe.
 
 ## Audience
+
 Developers and CI systems that need deterministic ordering while keeping human commentary intact.
 
-## Solution Overview
-`keepsorted` scans files, detects blocks marked for sorting or known file types, reorders items, and either rewrites files or reports required changes.
+## Goals
 
-## Key Modules
-- **CLI** parses flags and selects mode: check, diff, or fix.
-- **Core library** reads files, classifies them, and returns sorted content.
-- **Strategies** handle specific formats such as generic text, Bazel, Cargo.toml, gitignore/CODEOWNERS, and Rust `#[derive]` attributes.
-- **Optional features** enable additional strategies via command-line flags or crate features.
-- **Tests** include Rust unit tests and Bats end-to-end scripts.
+- Detect annotated blocks or supported file types that require sorting.
+- Reorder items deterministically while preserving associated comments.
+- Offer check, diff, and fix modes so projects can enforce or apply sorting.
+
+## Out of scope
+
+Custom sort orders for Rust derive macros. Derive attributes are always alphabetized to avoid bespoke rules for individual macros and to keep behavior predictable.

--- a/meta/WORKFLOW.md
+++ b/meta/WORKFLOW.md
@@ -1,32 +1,38 @@
 # WORKFLOW
 
 ## Environment Setup
-- Install the Rust toolchain from `rust-toolchain.toml` using `rustup`.
+
+- Install the Rust toolchain from `rust-toolchain.toml` with `rustup`.
 - Use isolated environments so tool versions do not bleed into other projects.
 
-## Dependencies and Tools
-- Manage libraries with Cargo and enable optional behaviour with feature flags.
-- End-to-end tests require the `bats` runner.
-- `verify.sh` sequences build, test, lint, format, sorting, and diff checks.
+## Local development
 
-## Local Checks
-For Rust or manifest changes run:
-```bash
-cargo build --release --all-targets
-cargo test
-cargo test --release
-cargo clippy --all-targets -- -D warnings
-cargo fmt --all -- --check
-./target/release/keepsorted --features gitignore,rust_derive_canonical $(git ls-files -z | grep -vzE '^tests/|^e2e-tests/|^README.md$' | xargs -0 -n1)
-bats e2e-tests
-./verify.sh
-```
-Markdown-only edits may skip these steps.
+- Format Markdown files with `mdformat`.
+- Run `./verify.sh` before committing. Without arguments it runs every check, or pass task names to limit the run.
+
+### verify.sh tasks
+
+| Argument | Runs | CI job |
+| --- | --- | --- |
+| `build` | `cargo build --release --all-targets` | build |
+| `test` | `cargo test` | test |
+| `test-release` | `cargo test --release` | test-release |
+| `clippy` | `cargo clippy --all-targets -- -D warnings` | lint |
+| `fmt` | `cargo fmt --all -- --check` | format |
+| `keepsorted` | run `keepsorted` on tracked files | sort |
+| `diff` | `git diff --exit-code` | diff |
+| `e2e` | `bats e2e-tests` | e2e |
+| `all` | all tasks above (default) | combined |
+
+Documentation-only changes may run `mdformat` and skip `verify.sh`.
 
 ## Continuous Integration
-GitHub Actions runs separate jobs for build, test, clippy, rustfmt, keepsorted, end-to-end tests, and ShellCheck across Linux and macOS.
 
-## Versioning and Releases
-- Follow Semantic Versioning and maintain `CHANGELOG.md` in Keep a Changelog format.
-- Add entries to the "Unreleased" section for user-facing changes.
-- Release flow: bump version in `Cargo.toml`, create a GitHub release tag with notes, then publish to crates.io (see `development-guide.md`).
+- GitHub Actions invokes `verify.sh` for build, test, lint, format, sort, diff, and end-to-end jobs so local runs match CI.
+- A dedicated job executes `mdformat --check` to enforce Markdown formatting.
+- PR titles must follow the Conventional Commits specification.
+
+## Release automation
+
+- Comment `prepare release vX.Y.Z` to begin a release.
+- The workflow opens a PR titled `chore(release): vX.Y.Z`; merging it tags the commit and runs the release pipeline automatically.


### PR DESCRIPTION
## Summary
- clarify product goals and note unsupported custom derive ordering
- document verify.sh tasks, mdformat, and release automation
- mention CI enforcement of markdown formatting and Conventional Commits

## Testing
- `mdformat meta/AGENTS.md meta/SPECS.md meta/WORKFLOW.md`


------
https://chatgpt.com/codex/tasks/task_e_6891af7ba968832dbb2c3ea00bfda102