### PR TITLE
docs(meta): outline training module

### DIFF
--- a/meta/SPECS.md
+++ b/meta/SPECS.md
@@ -20,3 +20,19 @@ Developers and CI systems that need deterministic ordering while keeping human c
 
 Custom sort orders for Rust derive macros.
 Derive attributes are either alphabetized or use canonical order.
+
+## Training Module
+
+The training module tunes strategy parameters by testing many
+configurations and ranking them with standard performance metrics.
+
+- Historical data is split into train and test sets. By default, the
+  most recent four months form the test window, but this period is
+  configurable.
+- Backtests run on the train portion for every parameter combination.
+- The best-performing configuration is evaluated on the held-out test
+  data.
+- Rankings use metrics such as return on investment and Sharpe ratio.
+- Output includes a concise summary file so results are easy to compare.
+- Runs are deterministic and optimized for quick feedback on demo
+  setups.

--- a/meta/SYSTEM.md
+++ b/meta/SYSTEM.md
@@ -1,17 +1,25 @@
 # SYSTEM
 
 ## Architecture
+
 - `main.rs` provides the CLI, parses arguments, and iterates over files.
 - `lib.rs` exposes `process_file` and `process_lines`, classifies each file, and dispatches to a strategy.
 - `src/strategies/` modules implement format-specific sorting and return reordered lines.
+- A training module splits historical data into train and test windows, runs
+  the evaluator across parameter grids, and reports the best configuration.
 
 Data flows from the CLI into the library, through a chosen strategy, and back out as sorted text which is checked, diffed, or written depending on the mode.
 
 ## Inputs and Outputs
+
 - Inputs: file paths or directories plus flags like `--mode`, `--features`, `--recursive`, and `--diff-command`.
-- Outputs: rewritten files, diff output, or status codes signalling success or failure.
+- Inputs for training include historical data sources, parameter ranges, and
+  an optional test-window override.
+- Outputs: rewritten files, diff output, status codes signalling success or
+  failure, and training summaries ranking configurations.
 
 ## Layout and Environment
+
 - Source lives under `src/` with `main.rs`, `lib.rs`, and strategy modules.
 - Tests reside in `tests/` for Rust units and `e2e-tests/` for Bats scripts.
 - Documentation and guides sit in `docs/` and the project root.
@@ -19,7 +27,10 @@ Data flows from the CLI into the library, through a chosen strategy, and back ou
 - Bats provides shell-based end-to-end testing.
 
 ## Design Decisions
+
 - Strategy modules keep file-specific logic isolated.
 - Experimental behaviours are gated behind features to avoid surprising users.
 - The tool delegates directory traversal to callers to stay small and predictable.
 - Comments are bound to following lines so annotations remain with their items after sorting.
+- Training runs are deterministic; by default the last four months of data are
+  held out for testing but this window can be configured.

--- a/meta/WORKFLOW.md
+++ b/meta/WORKFLOW.md
@@ -36,3 +36,15 @@ Documentation-only changes may run `mdformat` and skip `verify.sh`.
 
 - Comment `prepare release vX.Y.Z` to begin a release.
 - The workflow opens a PR titled `chore(release): vX.Y.Z`; merging it tags the commit and runs the release pipeline automatically.
+
+## Training Module
+
+1. Gather historical data and define the parameter ranges to explore.
+1. Optionally override the default four-month test window.
+1. Execute the training module to backtest each configuration on the train
+   split and score the winner on the held-out test data.
+1. Inspect the generated summary file to compare metrics like return on
+   investment or Sharpe ratio and choose a configuration.
+
+Runs are deterministic, so repeating the process with the same inputs yields
+identical summaries.


### PR DESCRIPTION
## Summary
- specify training module behavior and default data split in SPECS
- note training module's role and data flow in SYSTEM
- document how to run and review the training module in WORKFLOW

## Testing
- `mdformat meta/SPECS.md meta/SYSTEM.md meta/WORKFLOW.md`


------
https://chatgpt.com/codex/tasks/task_e_6891d113cf00832dbb2df724bdd4d747