### PR TITLE
docs(meta): expand contributor instructions

### DIFF
--- a/meta/AGENTS.md
+++ b/meta/AGENTS.md
@@ -2,20 +2,31 @@
 
 Guidelines for working with the contributor documentation in this folder.
 
-keepsorted is a Rust tool that sorts annotated lists while preserving nearby
-comments so configuration files and code blocks stay tidy.
+`keepsorted` sorts annotated lists while preserving nearby comments so
+configuration files and code blocks stay tidy.
 
-## Behaviors
+## Commit and PR conventions
 
-- Follow Conventional Commits for commit messages and PR titles.
-- For Rust or manifest changes, run each command in `verify.sh` and then the
-  script itself. Doc-only changes may skip these checks.
+- Commit messages and PR titles follow Conventional Commits.
+- File names and commit scopes use `snake_case` and lowercase.
+
+## Validation
+
+- For Rust source or manifest changes:
+  - Run each command from `verify.sh` individually.
+  - Then run `./verify.sh` to confirm success and a clean working tree.
+  - The PR fails if any command errors or if `git diff` shows changes.
+- Documentation-only changes:
+  - Run `mdformat` on modified Markdown files.
+  - Other verify steps may be skipped.
+
+## Environment and tools
+
 - Use the Rust version pinned in `rust-toolchain.toml`.
-- Keep lists and manifest sections sorted and update `CHANGELOG.md` for
-  user-facing changes.
+- Keep lists and manifest sections sorted; run `keepsorted` where annotated.
+- Update `CHANGELOG.md` for user-facing changes.
 - Do not modify `docs/specs.md` unless a human requests it.
-- Format Markdown with `mdformat`; CI runs a check to ensure files stay
-  formatted.
+- Markdown is formatted with `mdformat`; CI checks formatting.
 
 ## Reference
 
@@ -29,5 +40,4 @@ comments so configuration files and code blocks stay tidy.
 
 - Markdown files use `#` headings, wrap text reasonably, and rely on
   `mdformat` for consistent style.
-- File names and commit scopes use `snake_case` and lowercase.
 - Paths and examples assume the repository root unless noted.

--- a/meta/SPECS.md
+++ b/meta/SPECS.md
@@ -25,6 +25,33 @@ commentary intact.
 - Automatic discovery of files beyond paths explicitly provided.
 - Modifying unrelated formatting or comments.
 
+## Sorting behaviour
+
+- Groups consecutive comment lines with the following item and preserves that
+  association after sorting.
+- Directives:
+  - `# keepsorted: ignore file` — skip sorting for the entire file.
+  - `# keepsorted: ignore block` — skip the annotated block within a sorted
+    section.
+
+## Exit codes
+
+- `0` — success.
+- `1` — syntax errors in input.
+- `2` — incorrect command usage.
+- `3` — unexpected runtime failures.
+- `4` — check mode detected unsorted files.
+
+## Experimental features
+
+Disabled by default and enabled via `--features` or crate features:
+
+- `rust_derive_alphabetical` — sorts `#[derive(...)]` attributes alphabetically.
+- `rust_derive_canonical` — sorts `#[derive(...)]` attributes in canonical
+  Rust order.
+- `gitignore` — sorts `.gitignore` files.
+- `codeowners` — sorts `CODEOWNERS` files.
+
 ## Acceptance criteria
 
 A format or feature is complete when:

--- a/meta/SYSTEM.md
+++ b/meta/SYSTEM.md
@@ -9,20 +9,25 @@ sorting strategies.
 
 ## Components
 
-- **CLI (`src/main.rs`)** – parses arguments, iterates over files, and maps
-  library results to exit codes.
+- **CLI (`src/main.rs`)** – parses arguments with `clap`, iterates over files,
+  supports `--recursive` and `--diff-command`, and maps library results to exit
+  codes.
 - **Library (`src/lib.rs`)** – exposes `process_file` and `process_lines`,
   selects a strategy for each file, and applies the requested mode.
-- **Strategies (`src/strategies/*`)** – implement format-specific sorting
-  logic and return reordered lines.
+- **Strategies (`src/strategies/*`)** – implement format-specific sorting:
+  - `generic` – handles text blocks marked with `# Keep sorted`.
+  - `bazel` – sorts lists in Bazel `BUILD`/`.bzl` files.
+  - `cargo_toml` – sorts dependency tables in `Cargo.toml`.
+  - `gitignore` – sorts `.gitignore` and `CODEOWNERS` files when enabled.
+  - `rust_derive` – reorders `#[derive(...)]` attributes.
 - **Utilities** – helpers for comment binding, diff generation, and feature
   gating.
 
 ## Data flow
 
 1. The CLI gathers file paths and options from the user.
-1. The library classifies each file and selects an appropriate strategy.
-1. The chosen strategy sorts blocks and yields updated lines.
+1. `process_file` classifies each path and selects a strategy.
+1. The strategy reorders lines and preserves associated comments.
 1. The library applies `check`, `diff`, or `fix` and returns a result.
 1. The CLI writes diffs or files and exits with success or failure.
 

--- a/meta/WORKFLOW.md
+++ b/meta/WORKFLOW.md
@@ -33,16 +33,18 @@ Guides contributors through setup, development, testing, and releases.
 
 1. Create a branch and make changes.
 1. Keep lists sorted and update tests and docs alongside code.
-1. For documentation-only changes run `mdformat`.
-1. For Rust or manifest changes run each task in `./verify.sh` and then the
-   script itself:
-   - `cargo build --release --all-targets` – ensures the code compiles.
-   - `cargo test` and `cargo test --release` – verify behaviour.
-   - `cargo clippy --all-targets -- -D warnings` – enforce idiomatic Rust.
-   - `cargo fmt --all -- --check` – maintain consistent formatting.
-   - `keepsorted` – check that annotated lists stay ordered.
-   - `git diff --exit-code` – confirm a clean working tree.
-   - `bats e2e-tests` – exercise the CLI end to end.
+1. Documentation-only changes:
+   - Run `mdformat` on updated files.
+1. Rust or manifest changes:
+   - Run each task in `verify.sh` manually:
+     - `cargo build --release --all-targets` – ensures the code compiles.
+     - `cargo test` and `cargo test --release` – verify behaviour.
+     - `cargo clippy --all-targets -- -D warnings` – enforce idiomatic Rust.
+     - `cargo fmt --all -- --check` – maintain consistent formatting.
+     - `keepsorted` – check that annotated lists stay ordered.
+     - `bats e2e-tests` – exercise the CLI end to end.
+   - Run `./verify.sh` to ensure the tasks succeed and no files were modified.
+   - Use `git diff --exit-code` to confirm a clean working tree.
 1. Update `docs/` and `CHANGELOG.md` for user-facing changes.
 1. Commit with a Conventional Commit message.
 


### PR DESCRIPTION
## Summary
- clarify commit conventions, validation rules, and environment details in `meta/AGENTS.md`
- expand product guidance with sorting rules, exit codes, and experimental flags in `meta/SPECS.md`
- detail CLI options and strategy modules in `meta/SYSTEM.md`
- streamline development workflow guidance in `meta/WORKFLOW.md`

## Testing
- `mdformat meta/AGENTS.md meta/SPECS.md meta/SYSTEM.md meta/WORKFLOW.md`

------
https://chatgpt.com/codex/tasks/task_e_6892070d4128832d86c93b1504259c67