### PR TITLE
docs(workflow): consolidate release instructions

### DIFF
--- a/development-guide.md
+++ b/development-guide.md
@@ -1,36 +1,3 @@
 # Development Guide
 
-This guide describes how to prepare and publish a new release of the `keepsorted` crate to GitHub and [crates.io](https://crates.io/crates/keepsorted).
-
-## 1. Bump Version
-
-1. Update `keepsorted` version in `Cargo.toml`, example PR [#45](https://github.com/maksym-arutyunyan/keepsorted/pull/45/files)
-
-## 2. Create GitHub Release
-
-1. Identify the merge commit.
-2. Go to [Releases](https://github.com/maksym-arutyunyan/keepsorted/releases) → **Draft a new release**.
-3. Set:
-   - Tag: `vX.X.X`
-   - Target: the merge commit
-   - Title: `vX.X.X`
-   - Previous tag: last release
-   - Notes: click **Generate release notes**, edit if needed
-4. Summarize the highlights and add them to `CHANGELOG.md`.
-5. Click **Publish release**.
-
-## 3. Publish to crates.io
-
-1. Get a crates.io token at [Account Settings → API Tokens](https://crates.io/settings/tokens)
-2. Authenticate:
-   ```bash
-   cargo login
-   ```
-3. Check out the release tag:
-   ```bash
-   git checkout vX.X.X
-   ```
-4. Publish the crate:
-   ```bash
-   cargo publish -p keepsorted
-   ```
+Release instructions have moved to [meta/WORKFLOW.md](meta/WORKFLOW.md).

--- a/meta/WORKFLOW.md
+++ b/meta/WORKFLOW.md
@@ -89,6 +89,32 @@ match CI.
 - Track changes in `CHANGELOG.md`, grouping entries by prefix in this order:
   `feat`, `fix`, `refactor`, `test`, `docs`, `chore`. Preserve original order
   within each group.
-- Comment `prepare release vX.Y.Z` on the main branch to create a release PR.
-- A bot opens `chore(release): vX.Y.Z`; merging tags the commit and publishes
-  the release.
+
+### Release procedure
+
+1. Bump the `keepsorted` version in `Cargo.toml`.
+1. Draft a GitHub release:
+   - Identify the merge commit.
+   - Go to Releases → **Draft a new release**.
+   - Set:
+     - Tag: `vX.Y.Z`
+     - Target: the merge commit
+     - Title: `vX.Y.Z`
+     - Previous tag: last release
+     - Notes: click **Generate release notes**, edit if needed
+   - Summarize highlights in `CHANGELOG.md`.
+   - Click **Publish release**.
+1. Publish to crates.io:
+   - Get a token at crates.io.
+   - Authenticate:
+     ```bash
+     cargo login
+     ```
+   - Check out the release tag:
+     ```bash
+     git checkout vX.Y.Z
+     ```
+   - Publish the crate:
+     ```bash
+     cargo publish -p keepsorted
+     ```


### PR DESCRIPTION
## Summary
- migrate release guidance from `development-guide.md` into `meta/WORKFLOW.md`
- deprecate legacy `development-guide.md` in favor of `meta` docs

## Testing
- `mdformat meta/AGENTS.md meta/SPECS.md meta/SYSTEM.md meta/WORKFLOW.md development-guide.md`


------
https://chatgpt.com/codex/tasks/task_e_6892424e27b8832dafe0fa134e54cff0