### PR TITLE
docs: fix specs link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ configuration files and code blocks stay tidy.
 - Use the Rust version pinned in `rust-toolchain.toml`.
 - Keep lists and manifest sections sorted; run `keepsorted` where annotated.
 - Update `CHANGELOG.md` for user-facing changes.
-- Do not modify `docs/specs.md` unless a human requests it.
+- Do not modify `meta/SPECS.md` unless a human requests it.
 - Markdown is formatted with `mdformat`; CI checks formatting.
 
 ## Reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project are documented here.  
+All notable changes to this project are documented here.\
 This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
@@ -10,6 +10,7 @@ Adds quiet mode and skips binary files during recursive checks. Also drafts new 
 - feat: skip binary files during recursive traversal
 - feat: add `--quiet` flag to suppress informational output
 - docs: draft meta guidelines for AI and contributors
+- docs: fix specs link in README and AGENTS
 
 ## v0.1.6 – 2025-07-26
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # keepsorted
 
-[gh-image]: https://github.com/maksym-arutyunyan/keepsorted/workflows/CI/badge.svg
-[gh-checks]: https://github.com/maksym-arutyunyan/keepsorted/actions/workflows/workflow.yaml
-[cratesio-image]: https://img.shields.io/crates/v/keepsorted.svg
-[cratesio]: https://crates.io/crates/keepsorted
-[docsrs-image]: https://docs.rs/keepsorted/badge.svg
-[docsrs]: https://docs.rs/keepsorted
-
 [![keepsorted GitHub Actions][gh-image]][gh-checks]
 [![keepsorted on crates.io][cratesio-image]][cratesio]
 [![keepsorted on docs.rs][docsrs-image]][docsrs]
@@ -18,7 +11,7 @@ cargo install keepsorted
 - [Documentation](https://docs.rs/keepsorted)
 - [Source code](https://github.com/maksym-arutyunyan/keepsorted)
 - [Issue tracker](https://github.com/maksym-arutyunyan/keepsorted/issues)
-- [Specs](docs/specs.md)
+- [Specs](meta/SPECS.md)
 
 ## Overview
 
@@ -220,3 +213,9 @@ keepsorted file --features gitignore,rust_derive_canonical
 - Automatically detect project structure or configuration files.
 - Replace formatting tools like `rustfmt` or `prettier`.
 
+[cratesio]: https://crates.io/crates/keepsorted
+[cratesio-image]: https://img.shields.io/crates/v/keepsorted.svg
+[docsrs]: https://docs.rs/keepsorted
+[docsrs-image]: https://docs.rs/keepsorted/badge.svg
+[gh-checks]: https://github.com/maksym-arutyunyan/keepsorted/actions/workflows/workflow.yaml
+[gh-image]: https://github.com/maksym-arutyunyan/keepsorted/workflows/CI/badge.svg


### PR DESCRIPTION
## Summary
- correct specs link in README and AGENTS
- record docs fix in changelog

## Testing
- `./verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_689247cbe6d8832dbf4723b197be251e