### PR TITLE
fix: four correctness bugs in cargo_toml, rust_derive, and fix mode

### DIFF
--- a/e2e-tests/mode_fix.bats
+++ b/e2e-tests/mode_fix.bats
@@ -42,3 +42,15 @@ load './helpers.bash'
   diff -u "$expected" "$file"
 }
 
+@test "test \`--mode fix\` does not rewrite already-sorted file" {
+  local file inode_before inode_after
+  file=$(prepare_file generic/1_out.txt)
+  inode_before=$(stat -c '%i' "$file")
+
+  run_keepsorted --mode fix "$file"
+  [ "$status" -eq "$EXIT_SUCCESS" ]
+
+  inode_after=$(stat -c '%i' "$file")
+  [ "$inode_before" -eq "$inode_after" ]
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,6 +365,9 @@ fn handle_file(
             Ok(true)
         }
         Mode::Fix => {
+            if original == sorted {
+                return Ok(true);
+            }
             let dir = path.parent().unwrap_or(Path::new("."));
             let tmp = tempfile::NamedTempFile::new_in(dir)
                 .map_err(|e| AppError::runtime(format!("failed to create temp file: {}", e)))?;

--- a/src/strategies/cargo_toml.rs
+++ b/src/strategies/cargo_toml.rs
@@ -79,20 +79,16 @@ fn sort(block: Vec<String>, is_ignore_block_prev_line: bool) -> Vec<String> {
     let n = block.len();
     let mut items = Vec::with_capacity(n);
     let mut current_item = Item::default();
-    let mut is_multiline_code = false;
+    let mut depth = 0i32;
     for line in block {
-        if !is_multiline_code && is_single_line_comment(&line) {
+        if depth == 0 && is_single_line_comment(&line) {
             current_item.comment.push(line);
         } else {
-            let is_multi = is_multi_line_code(&line);
-            let is_completed = is_code_section_completed(&line);
+            depth += bracket_depth_delta(&line);
             current_item.code.push(line);
-            if is_multi {
-                is_multiline_code = true;
-            }
-            if !is_multiline_code || is_completed {
+            if depth <= 0 {
                 items.push(std::mem::take(&mut current_item));
-                is_multiline_code = false;
+                depth = 0;
             }
         }
     }
@@ -110,11 +106,17 @@ fn sort(block: Vec<String>, is_ignore_block_prev_line: bool) -> Vec<String> {
     result
 }
 
-fn contains_unquoted_bracket_or_brace(s: &str) -> bool {
+/// Returns the net change in bracket/brace nesting depth for a line.
+///
+/// Counts unquoted `{` and `[` as +1, unquoted `}` and `]` as -1.
+/// Characters inside quoted strings are ignored.
+fn bracket_depth_delta(line: &str) -> i32 {
+    let (code, _comment) = split_code_and_comment(line.trim());
     let mut in_string = false;
     let mut escape = false;
     let mut quote_char = b'\0';
-    for &c in s.as_bytes() {
+    let mut delta = 0i32;
+    for &c in code.as_bytes() {
         if in_string {
             if escape {
                 escape = false;
@@ -127,45 +129,12 @@ fn contains_unquoted_bracket_or_brace(s: &str) -> bool {
             in_string = true;
             quote_char = c;
         } else if c == b'{' || c == b'[' {
-            return true;
+            delta += 1;
+        } else if c == b'}' || c == b']' {
+            delta -= 1;
         }
     }
-    false
-}
-
-fn ends_with_unquoted_closing(s: &str) -> bool {
-    let mut in_string = false;
-    let mut escape = false;
-    let mut quote_char = b'\0';
-    let mut last_unquoted: Option<u8> = None;
-    for &c in s.as_bytes() {
-        if in_string {
-            if escape {
-                escape = false;
-            } else if c == b'\\' {
-                escape = true;
-            } else if c == quote_char {
-                in_string = false;
-            }
-        } else if c == b'"' || c == b'\'' {
-            in_string = true;
-            quote_char = c;
-            last_unquoted = None;
-        } else if !c.is_ascii_whitespace() {
-            last_unquoted = Some(c);
-        }
-    }
-    matches!(last_unquoted, Some(b'}') | Some(b']'))
-}
-
-fn is_multi_line_code(line: &str) -> bool {
-    let (code, _comment) = split_code_and_comment(line.trim());
-    contains_unquoted_bracket_or_brace(code)
-}
-
-fn is_code_section_completed(line: &str) -> bool {
-    let (code, _comment) = split_code_and_comment(line.trim());
-    ends_with_unquoted_closing(code.trim())
+    delta
 }
 
 #[cfg(test)]

--- a/src/strategies/cargo_toml.rs
+++ b/src/strategies/cargo_toml.rs
@@ -110,17 +110,62 @@ fn sort(block: Vec<String>, is_ignore_block_prev_line: bool) -> Vec<String> {
     result
 }
 
+fn contains_unquoted_bracket_or_brace(s: &str) -> bool {
+    let mut in_string = false;
+    let mut escape = false;
+    let mut quote_char = b'\0';
+    for &c in s.as_bytes() {
+        if in_string {
+            if escape {
+                escape = false;
+            } else if c == b'\\' {
+                escape = true;
+            } else if c == quote_char {
+                in_string = false;
+            }
+        } else if c == b'"' || c == b'\'' {
+            in_string = true;
+            quote_char = c;
+        } else if c == b'{' || c == b'[' {
+            return true;
+        }
+    }
+    false
+}
+
+fn ends_with_unquoted_closing(s: &str) -> bool {
+    let mut in_string = false;
+    let mut escape = false;
+    let mut quote_char = b'\0';
+    let mut last_unquoted: Option<u8> = None;
+    for &c in s.as_bytes() {
+        if in_string {
+            if escape {
+                escape = false;
+            } else if c == b'\\' {
+                escape = true;
+            } else if c == quote_char {
+                in_string = false;
+            }
+        } else if c == b'"' || c == b'\'' {
+            in_string = true;
+            quote_char = c;
+            last_unquoted = None;
+        } else if !c.is_ascii_whitespace() {
+            last_unquoted = Some(c);
+        }
+    }
+    matches!(last_unquoted, Some(b'}') | Some(b']'))
+}
+
 fn is_multi_line_code(line: &str) -> bool {
     let (code, _comment) = split_code_and_comment(line.trim());
-    code.contains('{') || code.contains('[')
+    contains_unquoted_bracket_or_brace(code)
 }
 
 fn is_code_section_completed(line: &str) -> bool {
-    // Split the line at the '#' character, take the first part, trim it,
-    // and check if it ends with '}' or ']'.
     let (code, _comment) = split_code_and_comment(line.trim());
-    let x = code.trim();
-    x.ends_with('}') || x.ends_with(']')
+    ends_with_unquoted_closing(code.trim())
 }
 
 #[cfg(test)]

--- a/src/strategies/rust_derive.rs
+++ b/src/strategies/rust_derive.rs
@@ -68,8 +68,8 @@ fn sort(block: Vec<String>, is_ignore_block_prev_line: bool, strategy: Strategy)
         .map(|line| line.trim_end_matches('\n'))
         .collect();
     let line = format!("{}\n", line);
-    let (line_without_comment, _comment) = split_code_and_line_comment(line.trim());
-    let line_without_comment = line_without_comment.trim();
+    let (code_raw, _comment) = split_code_and_line_comment(line.trim());
+    let line_without_comment = code_raw.trim();
 
     // Check if the line contains a #[derive(...)] statement
     if let Some(derive_range) = line_without_comment.find("#[derive(").and_then(|start| {
@@ -92,10 +92,11 @@ fn sort(block: Vec<String>, is_ignore_block_prev_line: bool, strategy: Strategy)
         let sorted_traits = traits.join(", ");
         let new_derive = format!("#[derive({})]", sorted_traits);
 
-        // Preserve the prefix and suffix whitespace
-        let prefix_whitespace = &line[..line.find(line_without_comment).unwrap_or(0)];
-        let suffix_whitespace =
-            &line[line_without_comment.len() + line.find(line_without_comment).unwrap_or(0)..];
+        // Compute prefix and suffix by measuring leading whitespace directly.
+        // Using find() would be fragile if line_without_comment appeared earlier in line.
+        let prefix_len = line.len() - line.trim_start().len();
+        let prefix_whitespace = &line[..prefix_len];
+        let suffix_whitespace = &line[prefix_len + line_without_comment.len()..];
 
         let new_line = format!("{}{}{}", prefix_whitespace, new_derive, suffix_whitespace);
         if new_line.trim_end_matches('\n').len() <= MAX_SINGLE_LINE_WIDTH {

--- a/src/tests/cargo_toml.rs
+++ b/src/tests/cargo_toml.rs
@@ -316,3 +316,40 @@ b = "2" # see [dev-dependencies] for the test version
         "#
     );
 }
+
+#[test]
+fn cargo_toml_brace_in_string_value() {
+    // A dep with '{' inside its string value must not trigger multiline mode,
+    // which would swallow the next dependency into the same item.
+    test_inner!(
+        CargoToml,
+        r#"
+[dependencies]
+b = "url/{version}/dist"
+a = "1"
+        "#,
+        r#"
+[dependencies]
+a = "1"
+b = "url/{version}/dist"
+        "#
+    );
+}
+
+#[test]
+fn cargo_toml_bracket_in_string_value() {
+    // A dep with '[' inside its string value must not trigger multiline mode.
+    test_inner!(
+        CargoToml,
+        r#"
+[dependencies]
+b = "feat[ure]"
+a = "1"
+        "#,
+        r#"
+[dependencies]
+a = "1"
+b = "feat[ure]"
+        "#
+    );
+}

--- a/src/tests/cargo_toml.rs
+++ b/src/tests/cargo_toml.rs
@@ -353,3 +353,33 @@ b = "feat[ure]"
         "#
     );
 }
+
+#[test]
+fn cargo_toml_nested_brackets_dont_close_early() {
+    // The inner ']' on the features line must not close multi-line mode —
+    // the outer '{' is still open. Without depth tracking, the two stray '}'
+    // lines sort independently and one of them ends up attached to the wrong item.
+    test_inner!(
+        CargoToml,
+        r#"
+[dependencies]
+c = {
+    features = ["x", "y"]
+}
+b = {
+    features = ["x", "y"]
+}
+a = "1"
+        "#,
+        r#"
+[dependencies]
+a = "1"
+b = {
+    features = ["x", "y"]
+}
+c = {
+    features = ["x", "y"]
+}
+        "#
+    );
+}

--- a/src/tests/rust_derive.rs
+++ b/src/tests/rust_derive.rs
@@ -334,3 +334,25 @@ struct Data {}
         "#
     );
 }
+
+#[test]
+fn rust_derive_indented_with_comment_containing_derive() {
+    // The comment contains the exact derive text. The offset calculation must
+    // use the leading-whitespace length directly, not find() — otherwise the
+    // indentation could be computed from the wrong occurrence.
+    test_inner!(
+        RustDeriveAlphabetical,
+        r#"
+mod foo {
+    #[derive(B, A)] // replaces #[derive(B, A)]
+    struct Data {}
+}
+        "#,
+        r#"
+mod foo {
+    #[derive(A, B)] // replaces #[derive(B, A)]
+    struct Data {}
+}
+        "#
+    );
+}


### PR DESCRIPTION
- **C1** `cargo_toml`: brackets inside quoted string values (e.g.
  `dep = "url/{ver}/dist"`) triggered multi-line mode, causing the next
  dependency to be absorbed into the same sort item and silently dropped.

- **C2** `cargo_toml`: multi-line mode used a boolean flag with no nesting
  depth awareness. An inner `[...]` on its own line closed the flag while an
  outer `{` was still open, corrupting output for multi-item blocks.

- **C3** `rust_derive`: prefix/suffix whitespace was recovered via
  `line.find(line_without_comment)`, which would return the wrong offset if
  the search string appeared earlier in the concatenated block. Replaced with
  direct length arithmetic.

- **C4** `main`: fix mode always wrote a temp file and replaced the original,
  even when content was unchanged — bumping mtime/inode unnecessarily.
  Added an early return when `original == sorted`.

Each fix includes a targeted test (unit tests for C1–C3, an e2e inode check
for C4).
