### PR TITLE
ci: harden, fix, and speed up CI pipeline

### DIFF
--- a/.github/workflows/ci-pr-only-cov.yaml
+++ b/.github/workflows/ci-pr-only-cov.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses: ytanikin/PRConventionalCommits@1.3.0
+        uses: ytanikin/PRConventionalCommits@b628c5a234cc32513014b7bfdd1e47b532124d98 # 1.3.0 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,22 +28,10 @@ jobs:
           cp target/release/keepsorted release/${{ matrix.asset_name }}
           tar -czvf ${{ matrix.asset_name }}.tar.gz -C release ${{ matrix.asset_name }}
 
-      - name: Upload Compressed Release Asset (tar.gz)
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Upload Release Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ matrix.asset_name }}.tar.gz
-          asset_name: ${{ matrix.asset_name }}.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload Original Binary
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2 — SHA-pinned; tags are mutable (CVE-2025-30066)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./release/${{ matrix.asset_name }}
-          asset_name: ${{ matrix.asset_name }}
-          asset_content_type: application/octet-stream
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ matrix.asset_name }}.tar.gz" \
+            "release/${{ matrix.asset_name }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
       - name: Build
         run: cargo build --release --all-targets

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,11 @@ jobs:
             name: linux64
             asset_name: keepsorted-linux64
           - os: macos-latest
-            name: macos
-            asset_name: keepsorted-macos
+            name: macos-aarch64
+            asset_name: keepsorted-macos-aarch64
+          - os: macos-13
+            name: macos-x86_64
+            asset_name: keepsorted-macos-x86_64
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,8 @@ jobs:
             asset_name: keepsorted-macos-x86_64
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
       - name: Build
         run: cargo build --release --all-targets

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
             asset_name: keepsorted-macos
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
       - name: Build
         run: cargo build --release --all-targets
@@ -29,7 +29,7 @@ jobs:
           tar -czvf ${{ matrix.asset_name }}.tar.gz -C release ${{ matrix.asset_name }}
 
       - name: Upload Compressed Release Asset (tar.gz)
-        uses: actions/upload-release-asset@v1.0.2
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2 — SHA-pinned; tags are mutable (CVE-2025-30066)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -39,7 +39,7 @@ jobs:
           asset_content_type: application/gzip
 
       - name: Upload Original Binary
-        uses: actions/upload-release-asset@v1.0.2
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2 — SHA-pinned; tags are mutable (CVE-2025-30066)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
       - name: Restore cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload binary
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           name: keepsorted-linux
           path: target/release/keepsorted
@@ -55,12 +55,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           lfs: true
 
       - name: Restore cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -81,10 +81,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
       - name: Restore cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
       - name: Install Rust + Rustfmt
         run: |
@@ -123,12 +123,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           lfs: true
 
       - name: Download binary
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           name: keepsorted-linux
           path: target/release
@@ -150,12 +150,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           lfs: true
 
       - name: Download binary
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           name: keepsorted-linux
           path: target/release
@@ -175,7 +175,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
       - name: Run shellcheck
         uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master — SHA-pinned; tags are mutable (CVE-2025-30066)

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,8 +28,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.rustup
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+          key: ${{ runner.os }}-rust-${{ env.RUST_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Install Rust
         run: |
@@ -38,6 +39,13 @@ jobs:
 
       - name: Build
         run: ./verify.sh build
+
+      - name: Upload binary
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+        with:
+          name: keepsorted-linux
+          path: target/release/keepsorted
 
   test:
     runs-on: ${{ matrix.os }}
@@ -58,8 +66,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.rustup
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+          key: ${{ runner.os }}-rust-${{ env.RUST_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Install Rust
         run: |
@@ -82,8 +91,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.rustup
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+          key: ${{ runner.os }}-rust-${{ env.RUST_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Install Rust + Clippy
         run: |
@@ -120,22 +130,14 @@ jobs:
         with:
           lfs: true
 
-      - name: Restore cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Download binary
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+          name: keepsorted-linux
+          path: target/release
 
-      - name: Install Rust
-        run: |
-          rustup update $RUST_VERSION --no-self-update
-          rustup default $RUST_VERSION
-
-      - name: Build Project
-        run: cargo build --release
+      - name: Mark binary executable
+        run: chmod +x target/release/keepsorted
 
       - name: Run KeepSorted
         shell: bash
@@ -155,25 +157,17 @@ jobs:
         with:
           lfs: true
 
-      - name: Restore cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Download binary
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+          name: keepsorted-linux
+          path: target/release
 
-      - name: Install Rust
-        run: |
-          rustup update $RUST_VERSION --no-self-update
-          rustup default $RUST_VERSION
+      - name: Mark binary executable
+        run: chmod +x target/release/keepsorted
 
       - name: Install Bats
-        run: sudo apt-get update && sudo apt-get install -y bats
-
-      - name: Build Project
-        run: cargo build --release
+        run: sudo apt-get install -y bats
 
       - name: Run e2e tests
         run: ./verify.sh e2e

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -19,9 +19,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -45,11 +45,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           lfs: true
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -69,9 +69,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
       - name: Install Rust + Rustfmt
         run: |
@@ -108,11 +108,11 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           lfs: true
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -141,11 +141,11 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           lfs: true
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -172,9 +172,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master — SHA-pinned; tags are mutable (CVE-2025-30066)
         env:
           SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -100,7 +100,7 @@ jobs:
           rustup default $RUST_VERSION
           rustup component add rustfmt
 
-      - name: Run Clippy
+      - name: Run rustfmt
         run: ./verify.sh fmt
 
   keepsorted:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,9 +28,8 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.rustup
             target
-          key: ${{ runner.os }}-rust-${{ env.RUST_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Install Rust
         run: |
@@ -66,9 +65,8 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.rustup
             target
-          key: ${{ runner.os }}-rust-${{ env.RUST_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Install Rust
         run: |
@@ -91,9 +89,8 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            ~/.rustup
             target
-          key: ${{ runner.os }}-rust-${{ env.RUST_VERSION }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Install Rust + Clippy
         run: |

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -19,9 +19,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Restore cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -45,11 +47,13 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           lfs: true
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Restore cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -69,9 +73,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Restore cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -92,7 +98,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
       - name: Install Rust + Rustfmt
         run: |
@@ -108,11 +115,13 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           lfs: true
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Restore cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -141,11 +150,13 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           lfs: true
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Restore cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
         with:
           path: |
             ~/.cargo/registry
@@ -172,9 +183,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 — SHA-pinned; tags are mutable (CVE-2025-30066)
 
-      - name: Run ShellCheck
+      - name: Run shellcheck
         uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master — SHA-pinned; tags are mutable (CVE-2025-30066)
         env:
           SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091

--- a/verify.sh
+++ b/verify.sh
@@ -23,7 +23,7 @@ Tasks:
   keepsorted    Run keepsorted on tracked files
   diff          Check that keepsorted made no changes
   e2e           Run Bats end-to-end tests
-  all           Run all checks (default)
+  all           Run all checks: test-release clippy fmt keepsorted diff e2e (default)
   -h, --help    Show this help message
 EOF
 }
@@ -124,7 +124,7 @@ for task in "${args[@]}"; do
       exit 0
       ;;
     all)
-      expanded_tasks+=(build test test-release clippy fmt keepsorted diff e2e)
+      expanded_tasks+=(test-release clippy fmt keepsorted diff e2e)
       ;;
     build|test|test-release|clippy|fmt|keepsorted|diff|e2e)
       expanded_tasks+=("$task")


### PR DESCRIPTION
- Pin all action references to commit SHAs (CVE-2025-30066); upgrade checkout/cache/artifact actions to Node.js 24-compatible versions.
- Replace archived `upload-release-asset` with `gh release upload`.
- Add Intel macOS build; rename artifacts with architecture qualifiers.
- Speed up pipeline: download pre-built binary in `keepsorted` and `e2e-tests` instead of rebuilding; drop `apt-get update` before bats.
- Fix misleading step name in rustfmt job; name all anonymous steps.
- Drop redundant `build` and `test` tasks from `verify.sh all`.
