### PR TITLE
fix: skip sorting multiline derives with inner inline comments

### DIFF
--- a/src/strategies/rust_derive.rs
+++ b/src/strategies/rust_derive.rs
@@ -63,9 +63,24 @@ fn sort(block: Vec<String>, is_ignore_block_prev_line: bool, strategy: Strategy)
     if is_ignore_block_prev_line || is_ignore_block(&block) {
         return block;
     }
-    // Strip // comments from each line before joining, so inner comments don't
-    // break the #[derive(...)] parser. Capture the trailing comment from the
-    // )] line for suffix preservation.
+
+    // If any inner item line carries an inline comment, leave the block unsorted
+    // rather than silently discarding the comments. Long-term, the fix is to
+    // pair each item with its comment, sort items while carrying comments along,
+    // and re-emit the block in multiline form — see the tracking issue for that.
+    let has_inner_comment = block.iter().any(|line| {
+        let stripped = line.trim_end_matches('\n');
+        let (code, comment) = split_code_and_line_comment(stripped);
+        // Allow comments on the opening `#[derive(` and closing `)]` lines;
+        // only bail out for comments attached to trait items in between.
+        !comment.is_empty() && !code.trim().starts_with("#[derive(") && !code.contains(")]")
+    });
+    if has_inner_comment {
+        return block;
+    }
+
+    // Strip // comments from each line before joining. Capture the trailing
+    // comment from the )] line for suffix preservation.
     let mut trailing_comment = String::new();
     let joined_code: String = block
         .iter()

--- a/src/tests/rust_derive.rs
+++ b/src/tests/rust_derive.rs
@@ -337,8 +337,9 @@ struct Data {}
 
 #[test]
 fn rust_derive_multiline_with_inner_comment() {
-    // A // comment on an inner line must not prevent sorting.
-    // The inner comment is dropped because multi-line derives are collapsed.
+    // When an item line carries an inline comment, the block is left unsorted
+    // to avoid silently discarding the comment. Sorting with comment
+    // preservation is tracked as a follow-up improvement.
     test_inner!(
         RustDeriveAlphabetical,
         r#"
@@ -350,7 +351,11 @@ fn rust_derive_multiline_with_inner_comment() {
 struct Data {}
         "#,
         r#"
-#[derive(A, B, C)]
+#[derive(
+    C,
+    B, // keep this
+    A,
+)]
 struct Data {}
         "#
     );


### PR DESCRIPTION
Rather than silently dropping inline comments attached to trait items, leave the block unsorted when any inner line carries a comment. This preserves all content at the cost of not sorting — safe over destructive.