### PR TITLE
fix: align diff command exit handling

### DIFF
--- a/e2e-tests/diff_command_tools.bats
+++ b/e2e-tests/diff_command_tools.bats
@@ -4,21 +4,21 @@ load './helpers.bash'
 
 @test "test \`--diff-command\` with git diff --no-index" {
   run_keepsorted --mode diff --diff-command "git diff --no-index" "e2e-tests/files/bazel/1_in.bazel"
-  [ "$status" -eq "$EXIT_SYNTAX_ERROR" ]
+  [ "$status" -eq "$EXIT_CHECK_FAILED" ]
   [[ "$output" == diff\ --git* ]]
 }
 
 @test "test \`--diff-command\` with colordiff" {
   command -v colordiff >/dev/null || skip "colordiff not installed"
   run_keepsorted --mode diff --diff-command "colordiff -u" "e2e-tests/files/bazel/1_in.bazel"
-  [ "$status" -eq "$EXIT_SYNTAX_ERROR" ]
+  [ "$status" -eq "$EXIT_CHECK_FAILED" ]
   [[ "$output" == *$'\e[0;31m'* ]]
 }
 
 @test "test \`--diff-command\` with delta" {
   command -v delta >/dev/null || skip "delta not installed"
   run_keepsorted --mode diff --diff-command "delta --paging=never" "e2e-tests/files/bazel/1_in.bazel"
-  [ "$status" -eq "$EXIT_SYNTAX_ERROR" ]
+  [ "$status" -eq "$EXIT_CHECK_FAILED" ]
   [[ "$output" == *"│"* ]]
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,6 @@ use std::process::{self, Command};
 ///
 /// clap also exits with this code on usage errors such as conflicting flags.
 const EXIT_USAGE_ERROR: i32 = 2;
-/// Exit code used for syntax errors in the input.
-const EXIT_SYNTAX_ERROR: i32 = 1;
 /// Exit code used for I/O problems or internal bugs.
 const EXIT_RUNTIME_ERROR: i32 = 3;
 /// Exit code used when `--mode check` or `--mode diff` detects unsorted files.
@@ -353,7 +351,7 @@ fn handle_file(
                     print!("{}", String::from_utf8_lossy(&output.stdout));
                     if !output.status.success() {
                         let code = output.status.code().unwrap_or(EXIT_RUNTIME_ERROR);
-                        let exit_code = if code == 1 { EXIT_SYNTAX_ERROR } else { code };
+                        let exit_code = if code == 1 { EXIT_CHECK_FAILED } else { code };
                         return Err(AppError::with_code(exit_code, ""));
                     }
                     return Ok(false);

--- a/verify.sh
+++ b/verify.sh
@@ -23,7 +23,7 @@ Tasks:
   keepsorted    Run keepsorted on tracked files
   diff          Check that keepsorted made no changes
   e2e           Run Bats end-to-end tests
-  all           Run all checks: test-release clippy fmt keepsorted diff e2e (default)
+  all           Run all checks: test-release clippy fmt build keepsorted diff e2e (default)
   -h, --help    Show this help message
 EOF
 }
@@ -124,7 +124,7 @@ for task in "${args[@]}"; do
       exit 0
       ;;
     all)
-      expanded_tasks+=(test-release clippy fmt keepsorted diff e2e)
+      expanded_tasks+=(test-release clippy fmt build keepsorted diff e2e)
       ;;
     build|test|test-release|clippy|fmt|keepsorted|diff|e2e)
       expanded_tasks+=("$task")


### PR DESCRIPTION
## Summary
- map custom diff command exit code 1 to the check/diff failure exit code
- include the release build in the default verifier flow before steps that require the binary
- update diff-command e2e expectations

## Tests
- cargo test
- bats e2e-tests/diff_command_tools.bats e2e-tests/mode_diff.bats
- ./verify.sh test-release clippy fmt build keepsorted e2e

Note: full `./verify.sh` reaches all checks but fails at the intentional `git diff` cleanliness gate while this PR has uncommitted changes in the working tree.