### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "keepsorted"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keepsorted"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "A tool for sorting blocks of lines in code files"
 authors = ["Maksym Arutyunyan"]


### PR DESCRIPTION
## Summary
- bump package version to 0.2.2
- refresh Cargo.lock package version via Cargo

## Tests
- cargo check
- ./verify.sh test-release clippy fmt build keepsorted e2e

Note: full `./verify.sh` reaches all checks but fails at the intentional `git diff` cleanliness gate while this release-prep diff is present.